### PR TITLE
add FlowPreview and UseExperimental annotations

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -28,6 +28,12 @@ dependencies {
 sourceCompatibility = "1.7"
 targetCompatibility = "1.7"
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions { 
+        freeCompilerArgs += ["-Xuse-experimental=kotlin.Experimental"]    
+    }
+}
+
 dokka {
     outputFormat = 'html'
     outputDirectory = "$buildDir/javadoc"

--- a/library/src/main/kotlin/com/freeletics/flowredux/FlowRedux.kt
+++ b/library/src/main/kotlin/com/freeletics/flowredux/FlowRedux.kt
@@ -1,5 +1,7 @@
 package com.freeletics.flowredux
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -20,6 +22,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 
+@FlowPreview
+@UseExperimental(ExperimentalCoroutinesApi::class)
 fun <A, S> Flow<A>.reduxStore(
     initialStateSupplier: () -> S,
     sideEffects: Iterable<SideEffect<S, A>>,
@@ -27,7 +31,7 @@ fun <A, S> Flow<A>.reduxStore(
 ): Flow<S> = flow {
 
     var currentState: S = initialStateSupplier()
-    val mutex: Mutex = Mutex()
+    val mutex = Mutex()
     val stateAccessor: StateAccessor<S> = { currentState }
 
     println("Emitting initial state")
@@ -77,6 +81,7 @@ fun <A, S> Flow<A>.reduxStore(
 
 }
 
+@UseExperimental(FlowPreview::class)
 fun main() = runBlocking {
     val sideEffect1: SideEffect<String, Int> = { action: Flow<Int>, stateAccessor: StateAccessor<String> ->
         action.flatMap { action ->

--- a/library/src/main/kotlin/com/freeletics/flowredux/ReducerException.kt
+++ b/library/src/main/kotlin/com/freeletics/flowredux/ReducerException.kt
@@ -1,7 +1,7 @@
 package com.freeletics.flowredux
 
 class ReducerException(
-        state: Any,
-        action: Any,
-        cause: Throwable
+    state: Any,
+    action: Any,
+    cause: Throwable
 ) : RuntimeException("Exception was thrown by reducer, state = '$state', action = '$action'", cause)

--- a/library/src/main/kotlin/com/freeletics/flowredux/SideEffect.kt
+++ b/library/src/main/kotlin/com/freeletics/flowredux/SideEffect.kt
@@ -1,19 +1,24 @@
 package com.freeletics.flowredux
 
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 
 /**
  * It is a function which takes a stream of actions and returns a stream of actions. Actions in, actions out
  * (concept borrowed from redux-observable.js.or - so called epics).
+ *
  * @param actions Input action. Every SideEffect should be responsible to handle a single Action
  * (i.e using filter or ofType operator)
  * @param state [StateAccessor] to get the latest state of the state machine
  */
+// @FlowPreview would be nicer because it's viral and let's the user know that this is using an
+// experimental API, but can't be used on a typealias. It's ok though because reduxStore has it.
+@UseExperimental(FlowPreview::class)
 // TODO find better name?
 typealias SideEffect<S, A> = (actions: Flow<A>, state: StateAccessor<S>) -> Flow<A>
 
 /**
- * The StateAccessor is basically just a deferred way to get a state of a [ObservableReduxStore] at any given point in time.
+ * The StateAccessor is basically just a deferred way to get a state of a [reduxStore] at any given point in time.
  * So you have to call this method to get the state.
  */
 // TODO find better name


### PR DESCRIPTION
`@FlowPreview` will make propagate the experimental warning to consumers of `reduxStore`. The warnings for using BroadcastChannel are suppressed because we only use it internally, meaning that consumers don't have to opt in to using `ExperimentalCoroutinesApi`.