### PR TITLE
fix only the first SideEffect getting called

### DIFF
--- a/library/src/main/kotlin/com/freeletics/flowredux/FlowRedux.kt
+++ b/library/src/main/kotlin/com/freeletics/flowredux/FlowRedux.kt
@@ -40,14 +40,13 @@ fun <A, S> Flow<A>.reduxStore(
         val actionBroadcastChannel: BroadcastChannel<A> = this@reduxStore.broadcastIn(this)
         val actionBroadcastChannelAsFlow: Flow<A> = actionBroadcastChannel.asFlow()
 
-        launch {
-
-            for (sideEffect in sideEffects) {
+        for (sideEffect in sideEffects) {
+            launch {
                 println("Subscribing sideeffect")
-
                 sideEffect(actionBroadcastChannelAsFlow, stateAccessor).collect { action: A ->
-                    // change state
                     println("Got action $action from sideeffect")
+
+                    // Change state
                     mutex.lock()
                     val newState: S = reducer(currentState, action)
                     currentState = newState
@@ -57,11 +56,13 @@ fun <A, S> Flow<A>.reduxStore(
                     // broadcast action
                     actionBroadcastChannel.send(action)
                 }
+                println("Completed sideeffect")
             }
         }
 
+        println("Subscribing upstream")
         collect { action: A ->
-            println("Received Action $action from upstream")
+            println("Received action $action from upstream")
 
             // Change State
             mutex.lock()
@@ -73,6 +74,7 @@ fun <A, S> Flow<A>.reduxStore(
             // React on actions from upstream by broadcasting Actions to SideEffects
             actionBroadcastChannel.send(action)
         }
+        println("Completed upstream")
     }
 
 }
@@ -81,8 +83,17 @@ fun main() = runBlocking {
     val sideEffect1: SideEffect<String, Int> = { action: Flow<Int>, stateAccessor: StateAccessor<String> ->
         action.flatMap { action ->
             println("-- SF1: Got action $action . current state ${stateAccessor()}")
-            if (action != 3)
+            if (action < 3)
                 flowOf(3)
+            else
+                emptyFlow()
+        }
+    }
+    val sideEffect2: SideEffect<String, Int> = { action: Flow<Int>, stateAccessor: StateAccessor<String> ->
+        action.flatMap { action ->
+            println("-- SF2: Got action $action . current state ${stateAccessor()}")
+            if (action < 3)
+                flowOf(4)
             else
                 emptyFlow()
         }
@@ -98,7 +109,7 @@ fun main() = runBlocking {
         //.delayFlow(1000)
         .reduxStore(
             initialStateSupplier = { "Start" },
-            sideEffects = listOf(sideEffect1)
+            sideEffects = listOf(sideEffect1, sideEffect2)
         ) { state, action ->
             state + action
         }


### PR DESCRIPTION
The issue was that the loop does not continue until the collect on the first one completes.

E.g.:
```
Emitting initial state
STATE: Start
Subscribing upstream
Subscribing sideeffect
Received action 1 from upstream
STATE: Start1
-- SF1: Got action 1 . current state Start1
Got action 3 from sideeffect
STATE: Start13
-- SF1: Got action 3 . current state Start13
-- SF1: Got action 1 . current state Start13
Got action 3 from sideeffect
STATE: Start133
-- SF1: Got action 3 . current state Start133
Received action 2 from upstream
STATE: Start1332
Completed upstream
-- SF1: Got action 2 . current state Start1332
Got action 3 from sideeffect
STATE: Start13323
-- SF1: Got action 3 . current state Start13323
-- SF1: Got action 2 . current state Start13323
Got action 3 from sideeffect
STATE: Start133233
Completed sideeffect
Subscribing sideeffect
Completed sideeffect
```
The last two lines is where it goes two the second side effect but everything is already processed.
