### PR TITLE
 only subscribe once to upstream, properly terminate

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,6 +34,7 @@ ext.versions = [
         espresso               : '3.0.2',
         screengrab             : '1.2.0',
         deviceAnimationsRule   : '0.0.2',
+        kotlintest             : '3.3.2',
 ]
 
 ext.libraries = [
@@ -79,7 +80,9 @@ ext.testLibraries = [
         espresso            : "com.android.support.test.espresso:espresso-core:$versions.espresso",
         espressoContrib     : "com.android.support.test.espresso:espresso-contrib:$versions.espresso",
         screengrab          : "tools.fastlane:screengrab:$versions.screengrab",
-        deviceAnimationsRule: "com.github.VictorAlbertos:DeviceAnimationTestRule:$versions.deviceAnimationsRule"
+        deviceAnimationsRule: "com.github.VictorAlbertos:DeviceAnimationTestRule:$versions.deviceAnimationsRule",
+        coroutinesTest      : "org.jetbrains.kotlinx:kotlinx-coroutines-test:$versions.coroutines",
+        kotlintest          : "io.kotlintest:kotlintest-runner-junit5:$versions.kotlintest"
 ]
 
 ext.gradlePlugins = [

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     api libraries.coroutines
 
     testImplementation testLibraries.junit
+    testImplementation testLibraries.kotlintest
+    testImplementation testLibraries.coroutinesTest
 }
 
 sourceCompatibility = "1.7"

--- a/library/src/main/kotlin/com/freeletics/flowredux/FlowRedux.kt
+++ b/library/src/main/kotlin/com/freeletics/flowredux/FlowRedux.kt
@@ -86,8 +86,8 @@ fun <A, S> Flow<A>.reduxStore(
 
 @UseExperimental(FlowPreview::class)
 fun main() = runBlocking {
-    val sideEffect1: SideEffect<String, Int> = { action: Flow<Int>, stateAccessor: StateAccessor<String> ->
-        action.flatMapConcat { action ->
+    val sideEffect1: SideEffect<String, Int> = { actions, stateAccessor ->
+        actions.flatMapConcat { action ->
             println("-- SF1: Got action $action . current state ${stateAccessor()}")
             if (action < 3)
                 flowOf(3)
@@ -95,8 +95,8 @@ fun main() = runBlocking {
                 emptyFlow()
         }
     }
-    val sideEffect2: SideEffect<String, Int> = { action: Flow<Int>, stateAccessor: StateAccessor<String> ->
-        action.flatMap { action ->
+    val sideEffect2: SideEffect<String, Int> = { actions, stateAccessor ->
+        actions.flatMapConcat { action ->
             println("-- SF2: Got action $action . current state ${stateAccessor()}")
             if (action < 3)
                 flowOf(4)

--- a/library/src/main/kotlin/com/freeletics/flowredux/FlowRedux.kt
+++ b/library/src/main/kotlin/com/freeletics/flowredux/FlowRedux.kt
@@ -3,22 +3,15 @@ package com.freeletics.flowredux
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BroadcastChannel
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.broadcastIn
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.delayEach
-import kotlinx.coroutines.flow.delayFlow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flatMap
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.reduce
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -42,18 +35,19 @@ fun <A, S> Flow<A>.reduxStore(
 
     coroutineScope {
 
-        val actionBroadcastChannel: BroadcastChannel<A> = this@reduxStore.broadcastIn(this)
+        val actionBroadcastChannel: BroadcastChannel<A> = BroadcastChannel(100)
         val actionBroadcastChannelAsFlow: Flow<A> = actionBroadcastChannel.asFlow()
 
         for (sideEffect in sideEffects) {
             launch {
                 println("Subscribing sideeffect")
                 sideEffect(actionBroadcastChannelAsFlow, stateAccessor).collect { action: A ->
-                    println("Got action $action from sideeffect")
+                    println("Received action $action from sideeffect")
 
                     // Change state
                     mutex.lock()
                     val newState: S = reducer(currentState, action)
+                    println("Reduce from sideeffect: $currentState with $action -> $newState")
                     currentState = newState
                     mutex.unlock()
                     emit(newState)
@@ -72,6 +66,7 @@ fun <A, S> Flow<A>.reduxStore(
             // Change State
             mutex.lock()
             val newState: S = reducer(currentState, action)
+            println("Reduce from upstream: $currentState with $action -> $newState")
             currentState = newState
             mutex.unlock()
             emit(newState)
@@ -80,6 +75,8 @@ fun <A, S> Flow<A>.reduxStore(
             actionBroadcastChannel.send(action)
         }
         println("Completed upstream")
+
+        actionBroadcastChannel.cancel()
     }
 
 }
@@ -100,6 +97,8 @@ fun main() = runBlocking {
             println("-- SF2: Got action $action . current state ${stateAccessor()}")
             if (action < 3)
                 flowOf(4)
+            else if (action < 4)
+                flowOf(5)
             else
                 emptyFlow()
         }

--- a/library/src/test/kotlin/com/freeletics/rxredux/FlowReduxTest.kt
+++ b/library/src/test/kotlin/com/freeletics/rxredux/FlowReduxTest.kt
@@ -1,0 +1,219 @@
+package com.freeletics.rxredux
+
+import com.freeletics.flowredux.SideEffect
+import com.freeletics.flowredux.reduxStore
+import io.kotlintest.matchers.collections.shouldContainExactly
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toCollection
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.withTimeout
+import org.junit.Ignore
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+@UseExperimental(FlowPreview::class)
+class FlowReduxTest {
+
+    private val counter = AtomicInteger()
+
+    @Test
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    fun `store without side effects`() = runBlockingTest {
+        val store = flow {
+            emit(counter.incrementAndGet())
+            emit(counter.incrementAndGet())
+        }.reduxStore({ "" }, listOf()) { state, action ->
+            state + action
+        }
+
+        store.toList() shouldContainExactly listOf("", "1", "12")
+    }
+
+    @Test
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    fun `store with empty side effect`() = runBlockingTest {
+        val sideEffect1: SideEffect<String, Int> = { _, _ -> emptyFlow() }
+
+        val store = flow {
+            emit(counter.incrementAndGet())
+            emit(counter.incrementAndGet())
+        }.reduxStore({ "" }, listOf(sideEffect1)) { state, action ->
+            state + action
+        }
+
+        store.toList() shouldContainExactly listOf("", "1", "12")
+    }
+
+    @Test
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    fun `store with empty flatMapped side effect`() = runBlockingTest {
+        val sideEffect1Actions = mutableListOf<Int>()
+        val sideEffect1: SideEffect<String, Int> = { actions, _ ->
+            actions.flatMapConcat { sideEffect1Actions.add(it); emptyFlow<Int>() }
+        }
+
+        val store = flow {
+            emit(counter.incrementAndGet())
+            emit(counter.incrementAndGet())
+        }.reduxStore({ "" }, listOf(sideEffect1)) { state, action ->
+            state + action
+        }
+
+        store.toList() shouldContainExactly listOf("", "1", "12")
+        sideEffect1Actions shouldContainExactly listOf(1, 2)
+    }
+
+    @Test
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    fun `store with 2 empty side effects`() = runBlockingTest {
+        val sideEffect1Actions = mutableListOf<Int>()
+        val sideEffect1: SideEffect<String, Int> = { actions, _ ->
+            actions.flatMapConcat { sideEffect1Actions.add(it); emptyFlow<Int>() }
+        }
+        val sideEffect2Actions = mutableListOf<Int>()
+        val sideEffect2: SideEffect<String, Int> = { actions, _ ->
+            actions.flatMapConcat { sideEffect2Actions.add(it); emptyFlow<Int>() }
+        }
+
+        val store = flow {
+            emit(counter.incrementAndGet())
+            emit(counter.incrementAndGet())
+        }.reduxStore({ "" }, listOf(sideEffect1, sideEffect2)) { state, action ->
+            state + action
+        }
+
+        store.toList() shouldContainExactly listOf("", "1", "12")
+        sideEffect1Actions shouldContainExactly listOf(1, 2)
+        sideEffect2Actions shouldContainExactly listOf(1, 2)
+    }
+
+    @Test
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    fun `store with 2 simple side effects`() = runBlockingTest {
+        val sideEffect1Actions = mutableListOf<Int>()
+        val sideEffect1: SideEffect<String, Int> = { actions, _ ->
+            actions.flatMapConcat {
+                sideEffect1Actions.add(it);
+                if (it < 6) {
+                    flowOf(6)
+                } else {
+                    emptyFlow()
+                }
+            }
+        }
+        val sideEffect2Actions = mutableListOf<Int>()
+        val sideEffect2: SideEffect<String, Int> = { actions, _ ->
+            actions.flatMapConcat {
+                sideEffect2Actions.add(it)
+                if (it < 6) {
+                    flowOf(7)
+                } else {
+                    emptyFlow()
+                }
+            }
+        }
+
+        val store = flow {
+            emit(counter.incrementAndGet())
+            emit(counter.incrementAndGet())
+        }.reduxStore({ "" }, listOf(sideEffect1, sideEffect2)) { state, action ->
+            state + action
+        }
+
+        store.toList() shouldContainExactly listOf("", "1", "16", "167", "1672", "16726", "167267")
+        sideEffect1Actions shouldContainExactly listOf(1, 6, 7, 2, 6, 7)
+        sideEffect2Actions shouldContainExactly listOf(1, 6, 7, 2, 6, 7)
+    }
+
+    @Test
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    fun `store with 2 multi value side effects`() = runBlockingTest {
+        val sideEffect1Actions = mutableListOf<Int>()
+        val sideEffect1: SideEffect<String, Int> = { actions, _ ->
+            actions.flatMapConcat {
+                sideEffect1Actions.add(it);
+                if (it < 6) {
+                    flowOf(6, 7)
+                } else {
+                    emptyFlow()
+                }
+            }
+        }
+        val sideEffect2Actions = mutableListOf<Int>()
+        val sideEffect2: SideEffect<String, Int> = { actions, _ ->
+            actions.flatMapConcat {
+                sideEffect2Actions.add(it)
+                if (it < 6) {
+                    flowOf(8, 9)
+                } else {
+                    emptyFlow()
+                }
+            }
+        }
+
+        val store = flow {
+            emit(counter.incrementAndGet())
+            emit(counter.incrementAndGet())
+        }.reduxStore({ "" }, listOf(sideEffect1, sideEffect2)) { state, action ->
+            state + action
+        }
+
+        store.toList() shouldContainExactly listOf("", "1", "16", "167", "1678", "16789", "167892", "1678926", "16789267", "167892678", "1678926789")
+        sideEffect1Actions shouldContainExactly listOf(1, 6, 7, 2, 6, 7)
+        sideEffect2Actions shouldContainExactly listOf(1, 6, 7, 2, 6, 7)
+    }
+
+    @Test
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    fun `store with 2 side effects which react to side effect actions`() = runBlockingTest {
+        val sideEffect1Actions = mutableListOf<Int>()
+        val sideEffect1: SideEffect<String, Int> = { actions, _ ->
+            actions.flatMapConcat {
+                println("SF0: got $it")
+                sideEffect1Actions.add(it);
+                if (it < 6) {
+                    flowOf(6)
+                } else if (it < 7) {
+                    flowOf(8)
+                } else {
+                    emptyFlow()
+                }
+            }
+        }
+        val sideEffect2Actions = mutableListOf<Int>()
+        val sideEffect2: SideEffect<String, Int> = { actions, _ ->
+            actions.flatMapConcat {
+                println("SF1: got $it")
+                sideEffect2Actions.add(it)
+                if (it < 6) {
+                    flowOf(7)
+                } else if (it < 7) {
+                    flowOf(9)
+                } else {
+                    emptyFlow()
+                }
+            }
+        }
+
+        val store = flow {
+            emit(counter.incrementAndGet())
+            emit(counter.incrementAndGet())
+        }.reduxStore({ "" }, listOf(sideEffect1, sideEffect2)) { state, action ->
+            state + action
+        }
+
+        store.toList() shouldContainExactly listOf("", "1", "16", "167", "1678", "16789", "167892", "1678926", "16789267", "167892678", "1678926789")
+        sideEffect1Actions shouldContainExactly listOf(1, 6, 7, 8, 9, 2, 6, 7, 8, 9)
+        sideEffect2Actions shouldContainExactly listOf(1, 6, 7, 8, 9, 2, 6, 7, 8, 9)
+    }
+
+    private suspend fun <T> Flow<T>.toList() = withTimeout(1000L) {
+        toCollection(mutableListOf())
+    }
+}


### PR DESCRIPTION
This fixes:
- receiving actions twice in side effects
- subscribing to the upstream twice
- returned Flow does not always complete when upstream completes

Open issues:
- SideEffects are called in a weird order (see the last two tests which are failing).
- When upstream completes SideEffects are not run on actions emitted by SideEffects in response to the last upstream action. So if upstream emits a `2`, the `2` is going through the reducer and the SideEffects. When a SideEffect emits an action in response to the `2` that action will go through the reducer, but not again to SideEffects. The cause for this is the BroadcastChannel being closed so send isn't working anymore. I'd say that this isn't a big issue because for redux use cases the upstream usually never completes.