### PR TITLE
cleanup

### DIFF
--- a/library/src/main/kotlin/com/freeletics/flowredux/FlowRedux.kt
+++ b/library/src/main/kotlin/com/freeletics/flowredux/FlowRedux.kt
@@ -4,20 +4,15 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 
+@ExperimentalCoroutinesApi
 @FlowPreview
-@UseExperimental(ExperimentalCoroutinesApi::class)
 fun <A, S> Flow<A>.reduxStore(
     initialStateSupplier: () -> S,
     sideEffects: Iterable<SideEffect<S, A>>,
@@ -28,9 +23,8 @@ fun <A, S> Flow<A>.reduxStore(
     val mutex = Mutex()
     val stateAccessor: StateAccessor<S> = { currentState }
 
-    println("Emitting initial state")
-
     // Emit the initial state
+    println("Emitting initial state")
     emit(currentState)
 
     coroutineScope {
@@ -78,5 +72,4 @@ fun <A, S> Flow<A>.reduxStore(
 
         actionBroadcastChannel.cancel()
     }
-
 }

--- a/library/src/test/kotlin/com/freeletics/flowredux/FlowReduxTest.kt
+++ b/library/src/test/kotlin/com/freeletics/flowredux/FlowReduxTest.kt
@@ -1,7 +1,5 @@
-package com.freeletics.rxredux
+package com.freeletics.flowredux
 
-import com.freeletics.flowredux.SideEffect
-import com.freeletics.flowredux.reduxStore
 import io.kotlintest.matchers.collections.shouldContainExactly
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -17,13 +15,12 @@ import org.junit.Ignore
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 
-@UseExperimental(FlowPreview::class)
+@UseExperimental(ExperimentalCoroutinesApi::class, FlowPreview::class)
 class FlowReduxTest {
 
     private val counter = AtomicInteger()
 
     @Test
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     fun `store without side effects`() = runBlockingTest {
         val store = flow {
             emit(counter.incrementAndGet())
@@ -36,8 +33,7 @@ class FlowReduxTest {
     }
 
     @Test
-    @UseExperimental(ExperimentalCoroutinesApi::class)
-    fun `store with empty side effect`() = runBlockingTest {
+    fun `store with unconnected empty side effect`() = runBlockingTest {
         val sideEffect1: SideEffect<String, Int> = { _, _ -> emptyFlow() }
 
         val store = flow {
@@ -51,8 +47,7 @@ class FlowReduxTest {
     }
 
     @Test
-    @UseExperimental(ExperimentalCoroutinesApi::class)
-    fun `store with empty flatMapped side effect`() = runBlockingTest {
+    fun `store with empty side effect`() = runBlockingTest {
         val sideEffect1Actions = mutableListOf<Int>()
         val sideEffect1: SideEffect<String, Int> = { actions, _ ->
             actions.flatMapConcat { sideEffect1Actions.add(it); emptyFlow<Int>() }
@@ -70,7 +65,6 @@ class FlowReduxTest {
     }
 
     @Test
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     fun `store with 2 empty side effects`() = runBlockingTest {
         val sideEffect1Actions = mutableListOf<Int>()
         val sideEffect1: SideEffect<String, Int> = { actions, _ ->
@@ -94,12 +88,11 @@ class FlowReduxTest {
     }
 
     @Test
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     fun `store with 2 simple side effects`() = runBlockingTest {
         val sideEffect1Actions = mutableListOf<Int>()
         val sideEffect1: SideEffect<String, Int> = { actions, _ ->
             actions.flatMapConcat {
-                sideEffect1Actions.add(it);
+                sideEffect1Actions.add(it)
                 if (it < 6) {
                     flowOf(6)
                 } else {
@@ -132,13 +125,12 @@ class FlowReduxTest {
     }
 
     @Test
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     @Ignore
     fun `store with 2 multi value side effects`() = runBlockingTest {
         val sideEffect1Actions = mutableListOf<Int>()
         val sideEffect1: SideEffect<String, Int> = { actions, _ ->
             actions.flatMapConcat {
-                sideEffect1Actions.add(it);
+                sideEffect1Actions.add(it)
                 if (it < 6) {
                     flowOf(6, 7)
                 } else {
@@ -172,13 +164,12 @@ class FlowReduxTest {
 
     @Test
     @Ignore
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     fun `store with 2 side effects which react to side effect actions`() = runBlockingTest {
         val sideEffect1Actions = mutableListOf<Int>()
         val sideEffect1: SideEffect<String, Int> = { actions, _ ->
             actions.flatMapConcat {
                 println("SF0: got $it")
-                sideEffect1Actions.add(it);
+                sideEffect1Actions.add(it)
                 if (it < 6) {
                     flowOf(6)
                 } else if (it < 7) {

--- a/library/src/test/kotlin/com/freeletics/flowredux/Main.kt
+++ b/library/src/test/kotlin/com/freeletics/flowredux/Main.kt
@@ -1,5 +1,6 @@
 package com.freeletics.flowredux
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
@@ -9,7 +10,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 
-@UseExperimental(FlowPreview::class)
+@UseExperimental(ExperimentalCoroutinesApi::class, FlowPreview::class)
 fun main() = runBlocking {
     val sideEffect1: SideEffect<String, Int> = { actions, stateAccessor ->
         actions.flatMapConcat { action ->


### PR DESCRIPTION
- improve how kotlin experimental annotations are applied
- unused imports
- test package name
- redundant semicolons
- small test name improvement