### PR TITLE
Use LATEST for the default flatMapPolicy of collectWhileInState and collectWhileInAnyState.

### DIFF
--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
@@ -82,7 +82,7 @@ class FlowReduxStoreBuilder<S : Any, A : Any> {
     //  in the block directly and folks can collect a particular flow directly
     fun <T> collectWhileInAnyState(
         flow: Flow<T>,
-        flatMapPolicy: FlatMapPolicy = FlatMapPolicy.CONCAT, // TODO should be latest?
+        flatMapPolicy: FlatMapPolicy = FlatMapPolicy.LATEST,
         block: StoreWideCollectorBlock<T, S>
     ) {
         val builder = StoreWideCollectBuilderBlock<T, S, A>(

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
@@ -31,7 +31,7 @@ class InStateBuilderBlock<S : Any, A : Any>(
 
     fun <T> collectWhileInState(
         flow: Flow<T>,
-        flatMapPolicy: FlatMapPolicy = FlatMapPolicy.CONCAT,
+        flatMapPolicy: FlatMapPolicy = FlatMapPolicy.LATEST,
         block: InStateObserverBlock<T, S>
     ) {
         _inStateSideEffectBuilders.add(


### PR DESCRIPTION
Per the [DSL docs](https://freeletics.github.io/FlowRedux/dsl/#flatmappolicy) the default `flatMapPolicy` of `collectWhileInState` should be `FlatMapPolicy.LATEST`. This PR changes both `collectWhileInState` and `collectWhileInAnyState` to use `FlatMapPolicy.LATEST` as default for consistency.

BTW I'd love to add some tests but I'm not sure if the APIs are stable enough to accept bigger contributions. Please let me know if there's anything we can help as external contributors. 😃