### PR TITLE
Fix LiveData type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ In an Android Application you would use it with AndroidX `ViewModel` like that:
 
 ```kotlin
 class MyViewModel @Inject constructor(private val stateMachine : StateMachine) : ViewModel() {
-    val state : LiveData<State> = MutableLiveData<State>()
+    val state = MutableLiveData<State>()
 
     init {
         viewModelScope.launch { // automatically canceled once ViewModel lifecycle reached destroyed.


### PR DESCRIPTION
In the README example, we are setting the state with `state.value = newState` which is only possible with `MutableLiveData`. Therefore we have to change the type from `LiveData` to `MutableLiveData`.