### PR TITLE
remove Channels from the reduxStore implementation

### DIFF
--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
@@ -7,14 +7,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
-import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 
 /**
  * Provides a fluent DSL to specify a ReduxStore
  */
-@FlowPreview
 @ExperimentalCoroutinesApi
 fun <S : Any, A : Any> Flow<A>.reduxStore(
     logger: FlowReduxLogger? = null,
@@ -40,7 +37,6 @@ fun <S : Any, A : Any> Flow<A>.reduxStore(
 /**
  * Provides a fluent DSL to specify a ReduxStore
  */
-@FlowPreview
 @ExperimentalCoroutinesApi
 fun <S : Any, A : Any> Flow<A>.reduxStore(
     logger: FlowReduxLogger? = null,

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
@@ -2,12 +2,10 @@ package com.freeletics.flowredux.dsl
 
 import com.freeletics.flowredux.FlowReduxLogger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
 
-@FlowPreview
 @ExperimentalCoroutinesApi
 abstract class FlowReduxStateMachine<S : Any, A : Any>(
     logger: FlowReduxLogger?,

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/FlowRedux.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/FlowRedux.kt
@@ -1,16 +1,11 @@
 package com.freeletics.flowredux
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.produceIn
-import kotlinx.coroutines.selects.select
 
 /**
  * Creates a Redux store with an initial state. If your initial state is an expensive computation
@@ -18,7 +13,6 @@ import kotlinx.coroutines.selects.select
  * first state lazily once the flow starts.
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <A, S> Flow<A>.reduxStore(
         initialState: S,
         sideEffects: Iterable<SideEffect<S, A>>,


### PR DESCRIPTION
This replaces the internal usages of channels by just merging the upstream actions and the actions emitted by side effects into one flow that than is collected. I'm not sure about all the issues that we had in the past before going to `select` and `onReceive` but back then we also used `launch` internally which we don't need here. Also collecting a `Flow` inside the `flow {}` builder is fine, so I think  this implementation should work.

There is one behavior change. Previously we had essentially 2+ action queues, one for actions coming from upstream and one  each for actions emitted by each side effect. The side effect action queues were always handled first and only if they were empty we would look at the next upstream action. Also within the side effects there was strict ordering by side effects (essentially the first side effect could starve all others by handling each action, including its own and always emitting a new action in response). 
Now there is just one queue were actions from everywhere are put it in. Since by default there is no concurrency in the store these are still ordered. So if there is an upstream action and each side effect immediately emits another action in response to that the side effect action will still arrive in the order of the side effects like before. So this does not introduce randomness.

The behavior change can be seen in the tests. With the now uncommented `delay(10)` in `store with 2 simple side effects` the test behaves like before. Without the delay (the added `store with 2 simple side effects no delay` test) the upstream `2` action reaches the reducer before the side effect actions because it was first in the shared queue of actions.