### PR TITLE
fix tests to some degree

### DIFF
--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateTest.kt
@@ -4,7 +4,6 @@ import app.cash.turbine.test
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.ExperimentalTime
@@ -15,32 +14,28 @@ import kotlinx.coroutines.FlowPreview
 class CollectWhileInStateTest {
 
     @Test
-    fun `collectWhileInState stops after having moved to next state`() {
+    fun `collectWhileInState stops after having moved to next state`() = suspendTest {
 
         val recordedValues = mutableListOf<Int>()
 
-        suspendTest {
-            val sm = StateMachine {
-                inState<TestState.Initial> {
-                    collectWhileInState(flow {
-                        emit(1)
-                        delay(10)
-                        emit(2)
-                        delay(10)
-                        emit(3)
-                    }) { v, _ ->
-                        recordedValues.add(v)
-                        return@collectWhileInState OverrideState(TestState.S1)
-                    }
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                collectWhileInState(flow {
+                    emit(1)
+                    delay(10)
+                    emit(2)
+                    delay(10)
+                    emit(3)
+                }) { v, _ ->
+                    recordedValues.add(v)
+                    return@collectWhileInState OverrideState(TestState.S1)
                 }
             }
+        }
 
-            launch {
-                sm.state.test {
-                    // switch to from Initial to S1 is immediate, before we start collecting
-                    assertEquals(TestState.S1, expectItem())
-                }
-            }
+        sm.state.test {
+            // switch to from Initial to S1 is immediate, before we start collecting
+            assertEquals(TestState.S1, expectItem())
         }
         assertEquals(listOf(1), recordedValues) // 2,3 is not emitted
     }
@@ -68,23 +63,21 @@ class CollectWhileInStateTest {
             }
         }
 
-        launch {
-            sm.state.test {
-                // switch to from Initial to S1 is immediate, before we start collecting
-                assertEquals(TestState.S1, expectItem())
+        sm.state.test {
+            // switch to from Initial to S1 is immediate, before we start collecting
+            assertEquals(TestState.S1, expectItem())
 
-                dispatchAsync(sm, TestAction.A1)
-                assertEquals(TestState.S2, expectItem())
+            dispatchAsync(sm, TestAction.A1)
+            assertEquals(TestState.S2, expectItem())
 
-                dispatchAsync(sm, TestAction.A2)
-                assertEquals(TestState.S1, expectItem())
+            dispatchAsync(sm, TestAction.A2)
+            assertEquals(TestState.S1, expectItem())
 
-                dispatchAsync(sm, TestAction.A1)
-                assertEquals(TestState.S2, expectItem())
+            dispatchAsync(sm, TestAction.A1)
+            assertEquals(TestState.S2, expectItem())
 
-                dispatchAsync(sm, TestAction.A2)
-                assertEquals(TestState.S1, expectItem())
-            }
+            dispatchAsync(sm, TestAction.A2)
+            assertEquals(TestState.S1, expectItem())
         }
     }
 }

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CustomIsInStateDslTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CustomIsInStateDslTest.kt
@@ -3,7 +3,6 @@ package com.freeletics.flowredux.dsl
 import app.cash.turbine.test
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.launch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -16,50 +15,44 @@ import kotlinx.coroutines.FlowPreview
 class CustomIsInStateDslTest {
 
     @Test
-    fun `on Action triggers only while in custom state`() {
+    fun `on Action triggers only while in custom state`() = suspendTest {
 
         var counter1 = 0
         var counter2 = 0
 
-        suspendTest {
-            val gs1 = TestState.GenericState("asd", 1)
-            val gs2 = TestState.GenericState("foo", 2)
+        val gs1 = TestState.GenericState("asd", 1)
+        val gs2 = TestState.GenericState("foo", 2)
 
-            val sm = StateMachine {
-                inState<TestState.Initial> {
-                    on<TestAction.A1> { _, _ ->
-                        OverrideState(gs1)
-                    }
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                on<TestAction.A1> { _, _ ->
+                    OverrideState(gs1)
                 }
-                inStateWithCondition(isInState = { it is TestState.GenericState && it.anInt == 1 }) {
-                    on<TestAction.A1> { _, _ ->
-                        counter1++
-                        OverrideState(gs2)
-                    }
-                }
-
-                inStateWithCondition(isInState = { it is TestState.GenericState && it.anInt == 2 }) {
-                    on<TestAction.A1> { _, _ ->
-                        delay(20) // wait for some time to see if not other state above triggers
-                        counter2++
-                        OverrideState(TestState.S1)
-                    }
+            }
+            inStateWithCondition(isInState = { it is TestState.GenericState && it.anInt == 1 }) {
+                on<TestAction.A1> { _, _ ->
+                    counter1++
+                    OverrideState(gs2)
                 }
             }
 
-            launch {
-                sm.state.test {
-                    assertEquals(TestState.Initial, expectItem())
-                    dispatchAsync(sm, TestAction.A1)
-                    assertEquals(gs1, expectItem())
-                    dispatchAsync(sm, TestAction.A1)
-                    assertEquals(gs2, expectItem())
-                    dispatchAsync(sm, TestAction.A1)
-                    assertEquals(TestState.S1, expectItem())
+            inStateWithCondition(isInState = { it is TestState.GenericState && it.anInt == 2 }) {
+                on<TestAction.A1> { _, _ ->
+                    delay(20) // wait for some time to see if not other state above triggers
+                    counter2++
+                    OverrideState(TestState.S1)
                 }
             }
+        }
 
-
+        sm.state.test {
+            assertEquals(TestState.Initial, expectItem())
+            dispatchAsync(sm, TestAction.A1)
+            assertEquals(gs1, expectItem())
+            dispatchAsync(sm, TestAction.A1)
+            assertEquals(gs2, expectItem())
+            dispatchAsync(sm, TestAction.A1)
+            assertEquals(TestState.S1, expectItem())
         }
 
         assertEquals(1, counter1)
@@ -67,49 +60,44 @@ class CustomIsInStateDslTest {
     }
 
     @Test
-    fun `collectWhileInState stops when leaving custom state`() {
+    fun `collectWhileInState stops when leaving custom state`() = suspendTest {
 
         var reached = false
 
-        suspendTest {
-            val gs1 = TestState.GenericState("asd", 1)
-            val gs2 = TestState.GenericState("2", 2)
+        val gs1 = TestState.GenericState("asd", 1)
+        val gs2 = TestState.GenericState("2", 2)
 
-            val sm = StateMachine {
-                inState<TestState.Initial> {
-                    on<TestAction.A1> { _, _ ->
-                        OverrideState(gs1)
-                    }
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                on<TestAction.A1> { _, _ ->
+                    OverrideState(gs1)
                 }
-                inStateWithCondition(isInState = { it is TestState.GenericState && it.anInt == 1 }) {
-                    collectWhileInState(flow {
-                        emit(2)
-                        delay(20)
-                        reached = true
-                        fail("This should never be reached")
-                    }) { value, _ ->
-                        OverrideState(TestState.GenericState(value.toString(), value))
-                    }
-                }
-
-                inStateWithCondition(isInState = { it is TestState.GenericState && it.anInt == 2 }) {
-                    onEnter {
-                        delay(50) // Wait until collectWhileInState succeeded
-                        return@onEnter OverrideState(TestState.S1)
-                    }
+            }
+            inStateWithCondition(isInState = { it is TestState.GenericState && it.anInt == 1 }) {
+                collectWhileInState(flow {
+                    emit(2)
+                    delay(20)
+                    reached = true
+                    fail("This should never be reached")
+                }) { value, _ ->
+                    OverrideState(TestState.GenericState(value.toString(), value))
                 }
             }
 
-            launch {
-                sm.state.test {
-                    assertEquals(TestState.Initial, expectItem())
-                    dispatchAsync(sm, TestAction.A1)
-                    assertEquals(gs1, expectItem())
-                    assertEquals(gs2, expectItem())
-                    assertEquals(TestState.S1, expectItem())
+            inStateWithCondition(isInState = { it is TestState.GenericState && it.anInt == 2 }) {
+                onEnter {
+                    delay(50) // Wait until collectWhileInState succeeded
+                    return@onEnter OverrideState(TestState.S1)
                 }
-
             }
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, expectItem())
+            dispatchAsync(sm, TestAction.A1)
+            assertEquals(gs1, expectItem())
+            assertEquals(gs2, expectItem())
+            assertEquals(TestState.S1, expectItem())
         }
 
         assertFalse(reached)

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachineTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachineTest.kt
@@ -21,7 +21,6 @@ class FlowReduxStateMachineTest {
         val sm = StateMachine { }
         sm.state.test {
             assertEquals(TestState.Initial, expectItem())
-            expectComplete()
         }
     }
 

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachineTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachineTest.kt
@@ -2,7 +2,6 @@ package com.freeletics.flowredux.dsl
 
 import app.cash.turbine.test
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlinx.coroutines.launch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachineTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachineTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertEquals
 import kotlin.test.fail
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.MainScope
@@ -18,11 +19,9 @@ class FlowReduxStateMachineTest {
     @Test
     fun `empty statemachine just emits initial state`() = suspendTest {
         val sm = StateMachine { }
-        launch {
-            sm.state.test {
-                assertEquals(TestState.Initial, expectItem())
-                expectComplete()
-            }
+        sm.state.test {
+            assertEquals(TestState.Initial, expectItem())
+            expectComplete()
         }
     }
 

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
@@ -2,7 +2,6 @@ package com.freeletics.flowredux.dsl
 
 import app.cash.turbine.test
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,67 +17,63 @@ class OnActionTest {
 
     @Test
     fun `action block stops when moved to another state`() = suspendTest {
-        launch {
-            var reached = false;
-            var reachedBefore = false
-            val sm = StateMachine {
-                inState<TestState.Initial> {
-                    on<TestAction.A1> { _, _ ->
-                        reachedBefore = true
-                        delay(delay)
-                        // this should never be reached because state transition did happen in the meantime,
-                        // therefore this whole block must be canceled
-                        reached = true
-                        OverrideState(TestState.S1)
-                    }
+        var reached = false;
+        var reachedBefore = false
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                on<TestAction.A1> { _, _ ->
+                    reachedBefore = true
+                    delay(delay)
+                    // this should never be reached because state transition did happen in the meantime,
+                    // therefore this whole block must be canceled
+                    reached = true
+                    OverrideState(TestState.S1)
+                }
 
-                    on<TestAction.A2> { _, _ ->
-                        OverrideState(TestState.S2)
-                    }
-
+                on<TestAction.A2> { _, _ ->
+                    OverrideState(TestState.S2)
                 }
 
             }
-            sm.state.test {
-                assertEquals(TestState.Initial, expectItem())
-                dispatchAsync(sm, TestAction.A1)
-                delay(delay/2)
-                dispatchAsync(sm, TestAction.A2)
-                assertTrue(reachedBefore)
-                assertFalse(reached)
-                assertEquals(TestState.S2, expectItem())
-                delay(delay)
-                expectComplete()
-            }
+
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, expectItem())
+            dispatchAsync(sm, TestAction.A1)
+            delay(delay/2)
+            dispatchAsync(sm, TestAction.A2)
+            assertTrue(reachedBefore)
+            assertFalse(reached)
+            assertEquals(TestState.S2, expectItem())
+            delay(delay)
+            expectNoEvents()
         }
     }
 
     @Test
     fun `on action gets triggered and moves to next state`() = suspendTest {
-
-        launch {
-            val sm = StateMachine {
-                inState<TestState.Initial> {
-                    on<TestAction.A1> { _, _ ->
-                        OverrideState(TestState.S1)
-                    }
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                on<TestAction.A1> { _, _ ->
+                    OverrideState(TestState.S1)
                 }
+            }
 
-                inState<TestState.S1> {
-                    on<TestAction.A2> { _, _ ->
-                        OverrideState(TestState.S2)
-                    }
-
+            inState<TestState.S1> {
+                on<TestAction.A2> { _, _ ->
+                    OverrideState(TestState.S2)
                 }
 
             }
-            sm.state.test {
-                assertEquals(TestState.Initial, expectItem())
-                dispatchAsync(sm, TestAction.A1)
-                assertEquals(TestState.S1, expectItem())
-                dispatchAsync(sm, TestAction.A2)
-                assertEquals(TestState.S2, expectItem())
-            }
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, expectItem())
+            dispatchAsync(sm, TestAction.A1)
+            assertEquals(TestState.S1, expectItem())
+            dispatchAsync(sm, TestAction.A2)
+            assertEquals(TestState.S2, expectItem())
         }
     }
 }

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterTest.kt
@@ -2,7 +2,6 @@ package com.freeletics.flowredux.dsl
 
 import app.cash.turbine.test
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,69 +17,63 @@ class OnEnterTest {
 
     @Test
     fun `onEnter block stops when moved to another state`() = suspendTest {
-        launch {
-            var reached = false;
-            var blockEntered = false
-            val sm = StateMachine {
-                inState<TestState.Initial> {
-                    onEnter {
-                        blockEntered = true
-                        delay(delay)
-                        // this should never be reached because state transition did happen in the meantime,
-                        // therefore this whole block must be canceled
-                        reached = true
-                        OverrideState(TestState.S1)
-                    }
+        var reached = false;
+        var blockEntered = false
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                onEnter {
+                    blockEntered = true
+                    delay(delay)
+                    // this should never be reached because state transition did happen in the meantime,
+                    // therefore this whole block must be canceled
+                    reached = true
+                    OverrideState(TestState.S1)
+                }
 
-                    on<TestAction.A2> { _, _ ->
-                        OverrideState(TestState.S2)
-                    }
+                on<TestAction.A2> { _, _ ->
+                    OverrideState(TestState.S2)
                 }
             }
+        }
 
-            sm.state.test {
-                assertEquals(TestState.Initial, expectItem())
-                delay(delay / 2)
-                assertTrue(blockEntered)
-                dispatchAsync(sm, TestAction.A2)
-                assertFalse(reached)
-                assertEquals(TestState.S2, expectItem())
-                delay(delay)
-                expectComplete()
-            }
+        sm.state.test {
+            assertEquals(TestState.Initial, expectItem())
+            delay(delay / 2)
+            assertTrue(blockEntered)
+            dispatchAsync(sm, TestAction.A2)
+            assertFalse(reached)
+            assertEquals(TestState.S2, expectItem())
+            delay(delay)
+            expectNoEvents()
         }
     }
 
     @Test
-    fun `on entering the same state doesnt trigger onEnter again`() {
-        suspendTest {
-            var s1Entered = 0
-            val sm = StateMachine {
-                inState<TestState.Initial> {
-                    onEnter { _ ->
-                        OverrideState(TestState.S1)
-                    }
-                }
-
-                inState<TestState.S1> {
-                    onEnter { _ ->
-                        s1Entered++
-                        MutateState { this }
-                    }
-                    on<TestAction.A1> { _, _ -> OverrideState(TestState.S1) }
+    fun `on entering the same state doesnt trigger onEnter again`() = suspendTest {
+        var s1Entered = 0
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                onEnter {
+                    OverrideState(TestState.S1)
                 }
             }
 
-            launch {
-                sm.state.test {
-                    // switch to from Initial to S1 is immediate, before we start collecting
-                    assertEquals(TestState.S1, expectItem())
-                    repeat(2) {
-                        dispatchAsync(sm, TestAction.A1) // Causes state transition to S1 again which is already current
-                        expectNoEvents()
-                        assertEquals(1, s1Entered)
-                    }
+            inState<TestState.S1> {
+                onEnter {
+                    s1Entered++
+                    MutateState { this }
                 }
+                on<TestAction.A1> { _, _ -> OverrideState(TestState.S1) }
+            }
+        }
+
+        sm.state.test {
+            // switch to from Initial to S1 is immediate, before we start collecting
+            assertEquals(TestState.S1, expectItem())
+            repeat(2) {
+                dispatchAsync(sm, TestAction.A1) // Causes state transition to S1 again which is already current
+                expectNoEvents()
+                assertEquals(1, s1Entered)
             }
         }
     }


### PR DESCRIPTION
The tests were generally not running correctly because runBlocking is not transitive. So if we `launch` inside the test to call `sm.state.test {}` nothing waits for that test block to finish. It just gets cancelled. This is most noticeable in the places where we had `expectComplete()`. The `Flow` returned by `reduxStore` (even without DSL) never completes, which shows those tests didn't actually fully run before.

The bad news is that the cancellation tests still work even though they shouldn't. Switching the dispatcher does break them but it also breaks tests that shouldn't break.I will look into that more.