### PR TITLE
fix issues hidden by Unconfined Dispatcher

### DIFF
--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -576,10 +576,9 @@ could complete before the first execution (because using a random time of waitin
 - `CONCAT`: In contrast to `MERGE` and `LATEST` `CONCAT` will not run `on<BarAction>` in parallel and will not cancel
   any previous execution. Instead, `CONCAT` will preserve the order and execute one block after another.
 
-All execution blocks can specify a `FlatMapPolicy`:
+All execution blocks except `onEnter` can specify a `FlatMapPolicy`:
 
 - `on<Action>(flatMapPolicy = FlatMapPolicy.LATEST){... }`
-- `onEnter(flatMapPolicy = FlatMapPolicy.LATEST) { ... }`
 - `collectWhileInState(flatMapPolicy = FlatMapPolicy.LATEST) { ... }`
 
 ## Best Practice

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
@@ -12,10 +12,12 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 
 /**
  * Provides a fluent DSL to specify a ReduxStore
  */
+@FlowPreview
 @ExperimentalCoroutinesApi
 fun <S : Any, A : Any> Flow<A>.reduxStore(
     logger: FlowReduxLogger? = null,
@@ -41,6 +43,7 @@ fun <S : Any, A : Any> Flow<A>.reduxStore(
 /**
  * Provides a fluent DSL to specify a ReduxStore
  */
+@FlowPreview
 @ExperimentalCoroutinesApi
 fun <S : Any, A : Any> Flow<A>.reduxStore(
     logger: FlowReduxLogger? = null,
@@ -49,6 +52,8 @@ fun <S : Any, A : Any> Flow<A>.reduxStore(
 ): Flow<S> =
     this.reduxStore(initialStateSupplier = { initialState }, logger = logger, block = block)
 
+@FlowPreview
+@ExperimentalCoroutinesApi
 class FlowReduxStoreBuilder<S : Any, A : Any> {
 
     // TODO is there a better workaround to hide implementation details like this while keep inline fun()

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
@@ -4,6 +4,7 @@ import com.freeletics.flowredux.FlowReduxLogger
 import com.freeletics.mad.statemachine.StateMachine
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,6 +13,7 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
+@FlowPreview
 @ExperimentalCoroutinesApi
 abstract class FlowReduxStateMachine<S : Any, A : Any>(
     private val initialState: S,

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
@@ -8,9 +8,13 @@ import com.freeletics.flowredux.dsl.internal.OnActionBlock
 import com.freeletics.flowredux.dsl.internal.OnActionInStateSideEffectBuilder
 import com.freeletics.flowredux.dsl.internal.OnEnterInStateSideEffectBuilder
 import com.freeletics.flowredux.dsl.internal.Working_CollectInStateBuilder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 
 // TODO @DslMarker
+@FlowPreview
+@ExperimentalCoroutinesApi
 class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
     /**
      * For private usage only

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
@@ -59,13 +59,11 @@ class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
      * TODO add a sample
      */
     fun onEnter(
-        flatMapPolicy: FlatMapPolicy = FlatMapPolicy.LATEST,
         block: InStateOnEnterBlock<InputState, S>
     ) {
         _inStateSideEffectBuilders.add(
             OnEnterInStateSideEffectBuilder(
                 isInState = _isInState,
-                flatMapPolicy = flatMapPolicy,
                 block = block
             )
         )

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/flow/WhileInState.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/flow/WhileInState.kt
@@ -1,0 +1,46 @@
+package com.freeletics.flowredux.dsl.flow
+
+import com.freeletics.flowredux.GetState
+import com.freeletics.flowredux.dsl.internal.Action
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+
+@ExperimentalCoroutinesApi
+internal fun <S, A> Flow<Action<S, A>>.whileInState(
+    isInState: (S) -> Boolean,
+    getState: GetState<S>,
+    transform: (Flow<Action<S, A>>) -> Flow<Action<S, A>>
+) = channelFlow {
+    var currentChannel: Channel<Action<S, A>>? = null
+
+    // collect upstream
+    collect { value ->
+        if (isInState(getState())) {
+            // if there is no Channel yet the state machine just entered the state
+            if (currentChannel == null) {
+                currentChannel = Channel()
+                launch {
+                    // transform actions sent to the the channel with the given function
+                    // and emit the result downstream
+                    transform(currentChannel!!.consumeAsFlow())
+                        .collect { send(it) }
+                }
+            }
+            // send the action to the transform because the state machin is in state
+            currentChannel!!.send(value)
+        } else {
+            // closing the channel with an exception will cancel the FlowCollector that
+            // collects it and thefor cancels the collection
+            currentChannel?.close(CancellationException("StateMachine left the state"))
+            currentChannel = null
+        }
+    }
+}

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnActionInStateSideEffectBuilder.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnActionInStateSideEffectBuilder.kt
@@ -7,14 +7,16 @@ import com.freeletics.flowredux.GetState
 import com.freeletics.flowredux.dsl.ChangeState
 import com.freeletics.flowredux.dsl.FlatMapPolicy
 import com.freeletics.flowredux.dsl.flow.flatMapWithPolicy
+import com.freeletics.flowredux.dsl.flow.whileInState
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.mapNotNull
 
+@FlowPreview
+@ExperimentalCoroutinesApi
 class OnActionInStateSideEffectBuilder<InputState : S, S : Any, A : Any>(
     private val isInState: (S) -> Boolean,
     internal val subActionClass: KClass<out A>,
@@ -22,44 +24,30 @@ class OnActionInStateSideEffectBuilder<InputState : S, S : Any, A : Any>(
     internal val onActionBlock: OnActionBlock<InputState, S, A>
 ) : InStateSideEffectBuilder<InputState, S, A>() {
 
-    @FlowPreview
-    @ExperimentalCoroutinesApi
     override fun generateSideEffect(): SideEffect<S, Action<S, A>> {
         return { actions: Flow<Action<S, A>>, getState: GetState<S> ->
 
-            actions
-                .filterStateAndUnwrapExternalAction(
-                    getState = getState
-                )
+            actions.whileInState(isInState, getState) { inStateAction ->
+                inStateAction.mapNotNull {
+                    when (it) {
+                        is ExternalWrappedAction<*, *> -> if (subActionClass.isInstance(it.action)) {
+                            it.action as A
+                        } else {
+                            null
+                        }
+                        is ChangeStateAction -> null
+                        is InitialStateAction -> null
+                    }
+                }
                 .flatMapWithPolicy(flatMapPolicy) { action ->
                     onActionSideEffectFactory(
                         action = action,
                         getState = getState
                     )
                 }
+            }
         }
     }
-
-    /**
-     * Creates a Flow that filters for a given (sub)state and (sub)action and returns a
-     * Flow of (sub)action
-     */
-    private fun Flow<Action<S, out A>>.filterStateAndUnwrapExternalAction(
-        getState: GetState<S>
-    ): Flow<A> =
-        this
-            .filter { action ->
-                val conditionHolds = isInState(getState()) &&
-                        action is ExternalWrappedAction &&
-                        subActionClass.isInstance(action.action)
-                conditionHolds
-            }.map {
-                when (it) {
-                    is ExternalWrappedAction<*, *> -> it.action as A
-                    is ChangeStateAction -> throw IllegalArgumentException("Internal bug. Please file an issue on Github")
-                    is InitialStateAction -> throw IllegalArgumentException("Internal bug. Please file an issue on Github")
-                }
-            }
 
     private fun onActionSideEffectFactory(
         action: A,

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnEnterInStateSideEffectBuilder.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnEnterInStateSideEffectBuilder.kt
@@ -3,13 +3,14 @@ package com.freeletics.flowredux.dsl.internal
 import com.freeletics.flowredux.SideEffect
 import com.freeletics.flowredux.GetState
 import com.freeletics.flowredux.dsl.ChangeState
-import com.freeletics.flowredux.dsl.FlatMapPolicy
-import com.freeletics.flowredux.dsl.flow.flatMapWithPolicy
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
 /**
  * A builder that generates a [SideEffect] that triggers every time the state machine enters
@@ -17,7 +18,6 @@ import kotlinx.coroutines.flow.flow
  */
 class OnEnterInStateSideEffectBuilder<InputState : S, S : Any, A : Any>(
     private val isInState: (S) -> Boolean,
-    private val flatMapPolicy: FlatMapPolicy,
     private val block: InStateOnEnterBlock<InputState, S>
 ) : InStateSideEffectBuilder<InputState, S, A>() {
 
@@ -26,10 +26,14 @@ class OnEnterInStateSideEffectBuilder<InputState : S, S : Any, A : Any>(
     override fun generateSideEffect(): SideEffect<S, Action<S, A>> {
         return { actions: Flow<Action<S, A>>, getState: GetState<S> ->
             actions
-                .mapStateChanges(isInState = isInState, getState = getState)
-                .filter { it == MapStateChange.StateChanged.ENTERED }
-                .flatMapWithPolicy(flatMapPolicy) {
-                    setStateFlow(getState)
+                .map { isInState(getState()) }
+                .distinctUntilChanged()
+                .flatMapLatest {
+                    if (it) {
+                        setStateFlow(getState)
+                    } else {
+                        flowOf()
+                    }
                 }
         }
     }

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateTest.kt
@@ -34,7 +34,7 @@ class CollectWhileInStateTest {
         }
 
         sm.state.test {
-            // switch to from Initial to S1 is immediate, before we start collecting
+            assertEquals(TestState.Initial, expectItem())
             assertEquals(TestState.S1, expectItem())
         }
         assertEquals(listOf(1), recordedValues) // 2,3 is not emitted
@@ -64,7 +64,7 @@ class CollectWhileInStateTest {
         }
 
         sm.state.test {
-            // switch to from Initial to S1 is immediate, before we start collecting
+            assertEquals(TestState.Initial, expectItem())
             assertEquals(TestState.S1, expectItem())
 
             dispatchAsync(sm, TestAction.A1)

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
@@ -64,7 +64,6 @@ class OnActionTest {
                 on<TestAction.A2> { _, _ ->
                     OverrideState(TestState.S2)
                 }
-
             }
         }
 

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
@@ -43,12 +43,13 @@ class OnActionTest {
             dispatchAsync(sm, TestAction.A1)
             delay(delay/2)
             dispatchAsync(sm, TestAction.A2)
-            assertTrue(reachedBefore)
-            assertFalse(reached)
             assertEquals(TestState.S2, expectItem())
             delay(delay)
             expectNoEvents()
         }
+
+        assertTrue(reachedBefore)
+        assertFalse(reached)
     }
 
     @Test

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterTest.kt
@@ -39,13 +39,14 @@ class OnEnterTest {
         sm.state.test {
             assertEquals(TestState.Initial, expectItem())
             delay(delay / 2)
-            assertTrue(blockEntered)
             dispatchAsync(sm, TestAction.A2)
-            assertFalse(reached)
             assertEquals(TestState.S2, expectItem())
             delay(delay)
             expectNoEvents()
         }
+
+        assertTrue(blockEntered)
+        assertFalse(reached)
     }
 
     @Test

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/StateMachine.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/StateMachine.kt
@@ -12,7 +12,7 @@ fun StateMachine(
 ): FlowReduxStateMachine<TestState, TestAction> {
     val sm = object : FlowReduxStateMachine<TestState, TestAction>(
         TestState.Initial,
-        CoroutineScope(Dispatchers.Unconfined),
+        CoroutineScope(Dispatchers.Default),
         CommandLineLogger
     ){
         init {


### PR DESCRIPTION
This replaces the dispatcher used in tests with `Dispatchers.Default`. There was a combination of things at play here.

1. Initial state is now visible to all tests again, this was expected from me. I only removed those expects in #130 because I had to use Unconfined
1. Any test that relied on a dispatched action for the first state change (`OnActionTest` and `CustomIsInStateDslTest`) was affected by an issue in `FlowReduxStateMachine`. Because of the launch that is done to start the store and it using `MutableSharedFlow` for incoming actions, any action that is dispatched before the launch body executes was lost. So the tests relying on an action didn't work. In real world use cases this is probably not an issue because you don't start dispatching actions a few millisecods later. I've changed the implementation to a `Channel` which will suspend the `dispatch` until we start collecting the actions.
1. The updated onEnter test was not set up for asynchronous events. `expectNoEvents` does not suspend or anything to wait that there are no more events, it just checks that there is nothing in it's queue. Because of the async dispatch of `A1` the following `assertEquals` happens too early and the counter is still 0 because not even `onEnter` of `S1` finished running yet. I've changed the test to use `GenericState` witch changing values so that we can wait for them with `expectItem` while still staying in the same state. The assertion that `onEnter` was only called once now happens after the `test` block when we know all invocations are done.

fixes #128, closes #171