### PR TITLE
break OnAction and OnEnter canellation tests

### DIFF
--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
@@ -43,12 +43,13 @@ class OnActionTest {
             dispatchAsync(sm, TestAction.A1)
             delay(delay/2)
             dispatchAsync(sm, TestAction.A2)
-            assertTrue(reachedBefore)
-            assertFalse(reached)
             assertEquals(TestState.S2, expectItem())
             delay(delay)
             expectNoEvents()
         }
+
+        assertTrue(reachedBefore)
+        assertFalse(reached)
     }
 
     @Test

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterTest.kt
@@ -39,13 +39,14 @@ class OnEnterTest {
         sm.state.test {
             assertEquals(TestState.Initial, expectItem())
             delay(delay / 2)
-            assertTrue(blockEntered)
             dispatchAsync(sm, TestAction.A2)
-            assertFalse(reached)
             assertEquals(TestState.S2, expectItem())
             delay(delay)
             expectNoEvents()
         }
+
+        assertTrue(blockEntered)
+        assertFalse(reached)
     }
 
     @Test


### PR DESCRIPTION
Builds on top of #169.

With all the other stuff out of the way I was now finally able to reproduce #128 in tests. Now that it's running asynchronously all that needed to be done is moving the `assertFalse` for reached down. Similar to case 3 in #169 the assertion happened before the action was processed in the state machine so `reached` was still `false` but it would change a bit later. It would have been enough to move them one line down after the next `expectItem` but I moved them to the end where they should always work.

Unfortunately I still can't break a test for #166/collectWhileInState.