### PR TITLE
deduplicate CollectInState code, update name

### DIFF
--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
@@ -2,12 +2,12 @@ package com.freeletics.flowredux.dsl
 
 import com.freeletics.flowredux.SideEffect
 import com.freeletics.flowredux.dsl.internal.Action
+import com.freeletics.flowredux.dsl.internal.CollectInStateBuilder
 import com.freeletics.flowredux.dsl.internal.InStateOnEnterBlock
 import com.freeletics.flowredux.dsl.internal.InStateSideEffectBuilder
 import com.freeletics.flowredux.dsl.internal.OnActionBlock
 import com.freeletics.flowredux.dsl.internal.OnActionInStateSideEffectBuilder
 import com.freeletics.flowredux.dsl.internal.OnEnterInStateSideEffectBuilder
-import com.freeletics.flowredux.dsl.internal.Working_CollectInStateBuilder
 import kotlinx.coroutines.flow.Flow
 
 // TODO @DslMarker
@@ -42,7 +42,7 @@ class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
         block: InStateObserverBlock<T, InputState, S>
     ) {
         _inStateSideEffectBuilders.add(
-            Working_CollectInStateBuilder(
+            CollectInStateBuilder(
                 isInState = _isInState,
                 flow = flow,
                 flatMapPolicy = flatMapPolicy,


### PR DESCRIPTION
Each when branch was identical except for the inner `flatMap...` call. Since we already have `flatMapWithPolicy` I've changed the inner flatMap to that and removed the when.

Also updates the name of the class because it's the only implementation by now.