### PR TITLE
remove onEnter flatMapPolicy and fix cancellation when leaving state

### DIFF
--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -576,10 +576,9 @@ could complete before the first execution (because using a random time of waitin
 - `CONCAT`: In contrast to `MERGE` and `LATEST` `CONCAT` will not run `on<BarAction>` in parallel and will not cancel
   any previous execution. Instead, `CONCAT` will preserve the order and execute one block after another.
 
-All execution blocks can specify a `FlatMapPolicy`:
+All execution blocks except `onEnter` can specify a `FlatMapPolicy`:
 
 - `on<Action>(flatMapPolicy = FlatMapPolicy.LATEST){... }`
-- `onEnter(flatMapPolicy = FlatMapPolicy.LATEST) { ... }`
 - `collectWhileInState(flatMapPolicy = FlatMapPolicy.LATEST) { ... }`
 
 ## Best Practice

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
@@ -59,13 +59,11 @@ class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
      * TODO add a sample
      */
     fun onEnter(
-        flatMapPolicy: FlatMapPolicy = FlatMapPolicy.LATEST,
         block: InStateOnEnterBlock<InputState, S>
     ) {
         _inStateSideEffectBuilders.add(
             OnEnterInStateSideEffectBuilder(
                 isInState = _isInState,
-                flatMapPolicy = flatMapPolicy,
                 block = block
             )
         )

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnEnterInStateSideEffectBuilder.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnEnterInStateSideEffectBuilder.kt
@@ -3,13 +3,14 @@ package com.freeletics.flowredux.dsl.internal
 import com.freeletics.flowredux.SideEffect
 import com.freeletics.flowredux.GetState
 import com.freeletics.flowredux.dsl.ChangeState
-import com.freeletics.flowredux.dsl.FlatMapPolicy
-import com.freeletics.flowredux.dsl.flow.flatMapWithPolicy
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
 /**
  * A builder that generates a [SideEffect] that triggers every time the state machine enters
@@ -17,7 +18,6 @@ import kotlinx.coroutines.flow.flow
  */
 class OnEnterInStateSideEffectBuilder<InputState : S, S : Any, A : Any>(
     private val isInState: (S) -> Boolean,
-    private val flatMapPolicy: FlatMapPolicy,
     private val block: InStateOnEnterBlock<InputState, S>
 ) : InStateSideEffectBuilder<InputState, S, A>() {
 
@@ -26,10 +26,14 @@ class OnEnterInStateSideEffectBuilder<InputState : S, S : Any, A : Any>(
     override fun generateSideEffect(): SideEffect<S, Action<S, A>> {
         return { actions: Flow<Action<S, A>>, getState: GetState<S> ->
             actions
-                .mapStateChanges(isInState = isInState, getState = getState)
-                .filter { it == MapStateChange.StateChanged.ENTERED }
-                .flatMapWithPolicy(flatMapPolicy) {
-                    setStateFlow(getState)
+                .map { isInState(getState()) }
+                .distinctUntilChanged()
+                .flatMapLatest {
+                    if (it) {
+                        setStateFlow(getState)
+                    } else {
+                        flowOf()
+                    }
                 }
         }
     }


### PR DESCRIPTION
Closes #171 and adresses the onEnter part of #128.

The old `flatMapWithPolicy` didn't get any events when leaving the state which is why it didn't cancel even if it was using `LATEST`. The new implementation turns each action emission to an `isInState` boolean and then has a `flatMapLatest` that will only return the onAction Flow if the boolean was true. This way the previous `Flow` will get cancelled when `isInState` changes from true to false. `distintUntilChanged` is used to ignore any additional emissions after the first `true`.

Instead of `map` to a boolean and `distintUntilChanged` this could also use `filterState` from the `CollectWhileInState` implementation. However this seems a lot less complex to me and I can't think of any issues with this implementation.