### PR TITLE
cancel onAction when leaving the current state

### DIFF
--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
@@ -12,10 +12,12 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 
 /**
  * Provides a fluent DSL to specify a ReduxStore
  */
+@FlowPreview
 @ExperimentalCoroutinesApi
 fun <S : Any, A : Any> Flow<A>.reduxStore(
     logger: FlowReduxLogger? = null,
@@ -41,6 +43,7 @@ fun <S : Any, A : Any> Flow<A>.reduxStore(
 /**
  * Provides a fluent DSL to specify a ReduxStore
  */
+@FlowPreview
 @ExperimentalCoroutinesApi
 fun <S : Any, A : Any> Flow<A>.reduxStore(
     logger: FlowReduxLogger? = null,
@@ -49,6 +52,8 @@ fun <S : Any, A : Any> Flow<A>.reduxStore(
 ): Flow<S> =
     this.reduxStore(initialStateSupplier = { initialState }, logger = logger, block = block)
 
+@FlowPreview
+@ExperimentalCoroutinesApi
 class FlowReduxStoreBuilder<S : Any, A : Any> {
 
     // TODO is there a better workaround to hide implementation details like this while keep inline fun()

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
@@ -4,6 +4,7 @@ import com.freeletics.flowredux.FlowReduxLogger
 import com.freeletics.mad.statemachine.StateMachine
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,6 +13,7 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
+@FlowPreview
 @ExperimentalCoroutinesApi
 abstract class FlowReduxStateMachine<S : Any, A : Any>(
     private val initialState: S,

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
@@ -8,9 +8,13 @@ import com.freeletics.flowredux.dsl.internal.OnActionBlock
 import com.freeletics.flowredux.dsl.internal.OnActionInStateSideEffectBuilder
 import com.freeletics.flowredux.dsl.internal.OnEnterInStateSideEffectBuilder
 import com.freeletics.flowredux.dsl.internal.Working_CollectInStateBuilder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 
 // TODO @DslMarker
+@FlowPreview
+@ExperimentalCoroutinesApi
 class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
     /**
      * For private usage only

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/flow/WhileInState.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/flow/WhileInState.kt
@@ -1,0 +1,46 @@
+package com.freeletics.flowredux.dsl.flow
+
+import com.freeletics.flowredux.GetState
+import com.freeletics.flowredux.dsl.internal.Action
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+
+@ExperimentalCoroutinesApi
+internal fun <S, A> Flow<Action<S, A>>.whileInState(
+    isInState: (S) -> Boolean,
+    getState: GetState<S>,
+    transform: (Flow<Action<S, A>>) -> Flow<Action<S, A>>
+) = channelFlow {
+    var currentChannel: Channel<Action<S, A>>? = null
+
+    // collect upstream
+    collect { value ->
+        if (isInState(getState())) {
+            // if there is no Channel yet the state machine just entered the state
+            if (currentChannel == null) {
+                currentChannel = Channel()
+                launch {
+                    // transform actions sent to the the channel with the given function
+                    // and emit the result downstream
+                    transform(currentChannel!!.consumeAsFlow())
+                        .collect { send(it) }
+                }
+            }
+            // send the action to the transform because the state machin is in state
+            currentChannel!!.send(value)
+        } else {
+            // closing the channel with an exception will cancel the FlowCollector that
+            // collects it and thefor cancels the collection
+            currentChannel?.close(CancellationException("StateMachine left the state"))
+            currentChannel = null
+        }
+    }
+}

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnActionInStateSideEffectBuilder.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnActionInStateSideEffectBuilder.kt
@@ -7,14 +7,16 @@ import com.freeletics.flowredux.GetState
 import com.freeletics.flowredux.dsl.ChangeState
 import com.freeletics.flowredux.dsl.FlatMapPolicy
 import com.freeletics.flowredux.dsl.flow.flatMapWithPolicy
+import com.freeletics.flowredux.dsl.flow.whileInState
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.mapNotNull
 
+@FlowPreview
+@ExperimentalCoroutinesApi
 class OnActionInStateSideEffectBuilder<InputState : S, S : Any, A : Any>(
     private val isInState: (S) -> Boolean,
     internal val subActionClass: KClass<out A>,
@@ -22,44 +24,30 @@ class OnActionInStateSideEffectBuilder<InputState : S, S : Any, A : Any>(
     internal val onActionBlock: OnActionBlock<InputState, S, A>
 ) : InStateSideEffectBuilder<InputState, S, A>() {
 
-    @FlowPreview
-    @ExperimentalCoroutinesApi
     override fun generateSideEffect(): SideEffect<S, Action<S, A>> {
         return { actions: Flow<Action<S, A>>, getState: GetState<S> ->
 
-            actions
-                .filterStateAndUnwrapExternalAction(
-                    getState = getState
-                )
+            actions.whileInState(isInState, getState) { inStateAction ->
+                inStateAction.mapNotNull {
+                    when (it) {
+                        is ExternalWrappedAction<*, *> -> if (subActionClass.isInstance(it.action)) {
+                            it.action as A
+                        } else {
+                            null
+                        }
+                        is ChangeStateAction -> null
+                        is InitialStateAction -> null
+                    }
+                }
                 .flatMapWithPolicy(flatMapPolicy) { action ->
                     onActionSideEffectFactory(
                         action = action,
                         getState = getState
                     )
                 }
+            }
         }
     }
-
-    /**
-     * Creates a Flow that filters for a given (sub)state and (sub)action and returns a
-     * Flow of (sub)action
-     */
-    private fun Flow<Action<S, out A>>.filterStateAndUnwrapExternalAction(
-        getState: GetState<S>
-    ): Flow<A> =
-        this
-            .filter { action ->
-                val conditionHolds = isInState(getState()) &&
-                        action is ExternalWrappedAction &&
-                        subActionClass.isInstance(action.action)
-                conditionHolds
-            }.map {
-                when (it) {
-                    is ExternalWrappedAction<*, *> -> it.action as A
-                    is ChangeStateAction -> throw IllegalArgumentException("Internal bug. Please file an issue on Github")
-                    is InitialStateAction -> throw IllegalArgumentException("Internal bug. Please file an issue on Github")
-                }
-            }
 
     private fun onActionSideEffectFactory(
         action: A,


### PR DESCRIPTION
Closes #128 

This one is more complex then fixing onEnter. Just the boolean that we have there because we still need the action value and new actions while we are in the state should not cancel the previous flow. We basically want a `flatMapSometimesLatest`. The new operator will put new upstream actions into a `Channel` when `isInState` is true. This `Channel` is then turned into a Flow and we apply our filtering and transformation with the flatMapPolicy on it. The resulting `Flow` gets collected and it's emissions are emitted to the downstream. When `isInState` becomes false the channel is closed so that the resulting flow will get cancelled as well.
