### PR TITLE
Print HTML Report for unit test result to console on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,11 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew build --stacktrace
+
+      - name: Print DSL module test results
+        if: ${{ failure() }}
+        run: cat /home/runner/work/FlowRedux/FlowRedux/dsl/build/reports/tests/allTests/index.html
+
+      - name: Print flowredux module test results
+          if: ${{ failure() }}
+          run: cat /home/runner/work/FlowRedux/FlowRedux/flowredux/build/reports/tests/allTests/index.html


### PR DESCRIPTION
Could also be stored as Artifacts, but in the long run I would rather like to have another integration that is able to pars the HTML properly (if XML reports cannot be created for multiplatform) and solve the problem that way (rather than spending time to setup storing artifacts)