### PR TITLE
make FlowReduxStateMachine lazy

### DIFF
--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateTest.kt
@@ -67,16 +67,16 @@ class CollectWhileInStateTest {
             assertEquals(TestState.Initial, expectItem())
             assertEquals(TestState.S1, expectItem())
 
-            dispatchAsync(sm, TestAction.A1)
+            sm.dispatchAsync(TestAction.A1)
             assertEquals(TestState.S2, expectItem())
 
-            dispatchAsync(sm, TestAction.A2)
+            sm.dispatchAsync(TestAction.A2)
             assertEquals(TestState.S1, expectItem())
 
-            dispatchAsync(sm, TestAction.A1)
+            sm.dispatchAsync(TestAction.A1)
             assertEquals(TestState.S2, expectItem())
 
-            dispatchAsync(sm, TestAction.A2)
+            sm.dispatchAsync(TestAction.A2)
             assertEquals(TestState.S1, expectItem())
         }
     }

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CustomIsInStateDslTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CustomIsInStateDslTest.kt
@@ -47,11 +47,11 @@ class CustomIsInStateDslTest {
 
         sm.state.test {
             assertEquals(TestState.Initial, expectItem())
-            dispatchAsync(sm, TestAction.A1)
+            sm.dispatchAsync(TestAction.A1)
             assertEquals(gs1, expectItem())
-            dispatchAsync(sm, TestAction.A1)
+            sm.dispatchAsync(TestAction.A1)
             assertEquals(gs2, expectItem())
-            dispatchAsync(sm, TestAction.A1)
+            sm.dispatchAsync(TestAction.A1)
             assertEquals(TestState.S1, expectItem())
         }
 
@@ -94,7 +94,7 @@ class CustomIsInStateDslTest {
 
         sm.state.test {
             assertEquals(TestState.Initial, expectItem())
-            dispatchAsync(sm, TestAction.A1)
+            sm.dispatchAsync(TestAction.A1)
             assertEquals(gs1, expectItem())
             assertEquals(gs2, expectItem())
             assertEquals(TestState.S1, expectItem())

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
@@ -40,9 +40,9 @@ class OnActionTest {
 
         sm.state.test {
             assertEquals(TestState.Initial, expectItem())
-            dispatchAsync(sm, TestAction.A1)
+            sm.dispatchAsync(TestAction.A1)
             delay(delay/2)
-            dispatchAsync(sm, TestAction.A2)
+            sm.dispatchAsync(TestAction.A2)
             assertEquals(TestState.S2, expectItem())
             delay(delay)
             expectNoEvents()
@@ -70,9 +70,9 @@ class OnActionTest {
 
         sm.state.test {
             assertEquals(TestState.Initial, expectItem())
-            dispatchAsync(sm, TestAction.A1)
+            sm.dispatchAsync(TestAction.A1)
             assertEquals(TestState.S1, expectItem())
-            dispatchAsync(sm, TestAction.A2)
+            sm.dispatchAsync(TestAction.A2)
             assertEquals(TestState.S2, expectItem())
         }
     }

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterTest.kt
@@ -39,7 +39,7 @@ class OnEnterTest {
         sm.state.test {
             assertEquals(TestState.Initial, expectItem())
             delay(delay / 2)
-            dispatchAsync(sm, TestAction.A2)
+            sm.dispatchAsync(TestAction.A2)
             assertEquals(TestState.S2, expectItem())
             delay(delay)
             expectNoEvents()

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/StateMachine.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/StateMachine.kt
@@ -1,24 +1,46 @@
 package com.freeletics.flowredux.dsl
 
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 fun StateMachine(
         builderBlock: FlowReduxStoreBuilder<TestState, TestAction>.() -> Unit
-): FlowReduxStateMachine<TestState, TestAction> {
-    val sm = object : FlowReduxStateMachine<TestState, TestAction>(
-        TestState.Initial,
-        CoroutineScope(Dispatchers.Default),
-        CommandLineLogger
-    ){
-        init {
-            spec(builderBlock)
+): TestStateMachine {
+    return TestStateMachine(builderBlock)
+}
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+class TestStateMachine  constructor(
+    val specBlock: FlowReduxStoreBuilder<TestState, TestAction>.() -> Unit
+) {
+
+    private val inputActions = Channel<TestAction>()
+
+    val state: Flow<TestState>
+        get() {
+        return inputActions
+            .consumeAsFlow()
+            .reduxStore(CommandLineLogger, TestState.Initial, specBlock)
+            .flowOn(Dispatchers.Default)
         }
+
+    suspend fun dispatch(action: TestAction) {
+        inputActions.send(action)
     }
 
-    return sm
+    @OptIn(DelicateCoroutinesApi::class)
+    fun dispatchAsync(action: TestAction) {
+        GlobalScope.launch {
+            dispatch(action)
+        }
+    }
 }

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/TestUtils.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/TestUtils.kt
@@ -8,10 +8,3 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 expect fun suspendTest(body: suspend CoroutineScope.() -> Unit)
-
-@OptIn(DelicateCoroutinesApi::class, FlowPreview::class, ExperimentalCoroutinesApi::class)
-fun dispatchAsync(sm: FlowReduxStateMachine<TestState, TestAction>, action: TestAction) {
-    GlobalScope.launch {
-        sm.dispatch(action)
-    }
-}


### PR DESCRIPTION
This pr changes that the `FlowReduxStateMachine` does not immediately launch something when spec is called, which usually happens in the constructor. Instead it will just create a `StateFlow` there that has `SharingStarted.Lazily`. This makes it so that the collection of upstream only starts with the first subscriber. It's basically only becoming hot at that point.

Part 2: Don't use `FlowReduxStateMachine` in tests but instead a similar class that does not use `stateIn`. The reason for that is that `StateFlow` conflates values. If the state machine switches states immediately after we start the collection (even with the lazy changes mentioned above) if the  collector from turbine didn't get the initial state yet, then StateFlow will not emit it. 