### PR TITLE
simplify CollectInStateSideEffectBuilder implementation

### DIFF
--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/flow/MapToIsInState.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/flow/MapToIsInState.kt
@@ -1,0 +1,15 @@
+package com.freeletics.flowredux.dsl.flow
+
+import com.freeletics.flowredux.GetState
+import com.freeletics.flowredux.dsl.internal.Action
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+internal fun <S, A> Flow<Action<S, A>>.mapToIsInState(
+    isInState: (S) -> Boolean,
+    getState: GetState<S>,
+) : Flow<Boolean> {
+    return map { isInState(getState()) }
+        .distinctUntilChanged()
+}

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CollectInStateSideEffectBuilder.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CollectInStateSideEffectBuilder.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -38,15 +39,15 @@ internal class CollectInStateBuilder<T, InputState : S, S : Any, A : Any>(
     override fun generateSideEffect(): SideEffect<S, Action<S, A>> {
         return { actions: Flow<Action<S, A>>, getState: GetState<S> ->
             actions
-                .filterState(getState = getState, isInState = isInState)
-                .flatMapLatest { stateSubscription ->
-                    when (stateSubscription) {
-                        FilterState.StateChanged.SUBSCRIBE -> {
-                            flow.flatMapWithPolicy(flatMapPolicy) {
-                                setStateFlow(value = it, getState = getState)
-                            }
+                .map { isInState(getState()) }
+                .distinctUntilChanged()
+                .flatMapLatest {
+                    if (it) {
+                        flow.flatMapWithPolicy(flatMapPolicy) {
+                            setStateFlow(value = it, getState = getState)
                         }
-                        FilterState.StateChanged.UNSUBSCRIBE -> flow { }
+                    } else {
+                        flowOf()
                     }
                 }
         }
@@ -68,86 +69,4 @@ internal class CollectInStateBuilder<T, InputState : S, S : Any, A : Any>(
             )
         }
     }
-
-    /**
-     * Internal implementation of an operator that keeps track if you have to subscribe
-     * or unsubscribe of a certain Flow.
-     *
-     */
-    private class FilterState<S : Any, A : Any>(
-        actions: Flow<Action<S, A>>,
-        getState: GetState<S>,
-        private val isInState: (S) -> Boolean
-    ) {
-
-        private enum class InternalStateChangedSubscription {
-            SUBSCRIBE, UNSUBSCRIBE, DO_NOTHING
-        }
-
-        enum class StateChanged {
-            SUBSCRIBE, UNSUBSCRIBE
-        }
-
-        private val mutex = Mutex()
-        private var lastState: S? = null
-
-        val flow: Flow<StateChanged> = actions.map {
-            mutex.withLock {
-
-                val state = getState()
-                val previousState = lastState
-                val isInExpectedState = isInState(state)
-                val previousStateInExpectedState = if (previousState == null) {
-                    false
-                } else {
-                    isInState(previousState)
-                }
-
-                if (previousState == null) {
-                    if (isInExpectedState) {
-                        InternalStateChangedSubscription.SUBSCRIBE
-                    } else {
-                        InternalStateChangedSubscription.DO_NOTHING
-                    }
-                } else {
-                    when {
-                        isInExpectedState && previousStateInExpectedState -> InternalStateChangedSubscription.DO_NOTHING
-                        isInExpectedState && !previousStateInExpectedState -> InternalStateChangedSubscription.SUBSCRIBE
-                        !isInExpectedState && previousStateInExpectedState -> InternalStateChangedSubscription.UNSUBSCRIBE
-                        !isInExpectedState && !previousStateInExpectedState -> InternalStateChangedSubscription.DO_NOTHING
-                        else -> throw IllegalStateException(
-                            "An internal error occurred: " +
-                                    "isInExpectedState: $isInExpectedState" +
-                                    "and previousStateInExpectedState: $previousStateInExpectedState " +
-                                    "is not possible. Please file an issue on Github."
-                        )
-
-                    }
-                }.also {
-                    lastState = state
-                }
-
-            }
-        }
-            .filter { it != InternalStateChangedSubscription.DO_NOTHING }
-            .distinctUntilChanged()
-            .map {
-                when (it) {
-                    InternalStateChangedSubscription.SUBSCRIBE -> StateChanged.SUBSCRIBE
-                    InternalStateChangedSubscription.UNSUBSCRIBE -> StateChanged.UNSUBSCRIBE
-                    InternalStateChangedSubscription.DO_NOTHING -> throw IllegalStateException(
-                        "Internal Error occurred. File an issue on Github."
-                    )
-                }
-            }
-    }
-
-    private fun Flow<Action<S, A>>.filterState(
-        getState: GetState<S>,
-        isInState: (S) -> Boolean
-    ): Flow<FilterState.StateChanged> = FilterState<S, A>(
-        actions = this,
-        isInState = isInState,
-        getState = getState
-    ).flow
 }

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CollectInStateSideEffectBuilder.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CollectInStateSideEffectBuilder.kt
@@ -47,7 +47,7 @@ internal class CollectInStateBuilder<T, InputState : S, S : Any, A : Any>(
                             setStateFlow(value = it, getState = getState)
                         }
                     } else {
-                        flowOf()
+                        emptyFlow()
                     }
                 }
         }

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CollectInStateSideEffectBuilder.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CollectInStateSideEffectBuilder.kt
@@ -5,17 +5,13 @@ import com.freeletics.flowredux.GetState
 import com.freeletics.flowredux.dsl.FlatMapPolicy
 import com.freeletics.flowredux.dsl.InStateObserverHandler
 import com.freeletics.flowredux.dsl.flow.flatMapWithPolicy
+import com.freeletics.flowredux.dsl.flow.mapToIsInState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 /**
  * A builder to create a [SideEffect] that observes a Flow<T> as long as the redux store is in
@@ -39,8 +35,7 @@ internal class CollectInStateBuilder<T, InputState : S, S : Any, A : Any>(
     override fun generateSideEffect(): SideEffect<S, Action<S, A>> {
         return { actions: Flow<Action<S, A>>, getState: GetState<S> ->
             actions
-                .map { isInState(getState()) }
-                .distinctUntilChanged()
+                .mapToIsInState(isInState, getState)
                 .flatMapLatest {
                     if (it) {
                         flow.flatMapWithPolicy(flatMapPolicy) {

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnEnterInStateSideEffectBuilder.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnEnterInStateSideEffectBuilder.kt
@@ -32,7 +32,7 @@ class OnEnterInStateSideEffectBuilder<InputState : S, S : Any, A : Any>(
                     if (it) {
                         setStateFlow(getState)
                     } else {
-                        flowOf()
+                        emptyFlow()
                     }
                 }
         }

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnEnterInStateSideEffectBuilder.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/OnEnterInStateSideEffectBuilder.kt
@@ -3,14 +3,13 @@ package com.freeletics.flowredux.dsl.internal
 import com.freeletics.flowredux.SideEffect
 import com.freeletics.flowredux.GetState
 import com.freeletics.flowredux.dsl.ChangeState
+import com.freeletics.flowredux.dsl.flow.mapToIsInState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 
 /**
  * A builder that generates a [SideEffect] that triggers every time the state machine enters
@@ -26,8 +25,7 @@ class OnEnterInStateSideEffectBuilder<InputState : S, S : Any, A : Any>(
     override fun generateSideEffect(): SideEffect<S, Action<S, A>> {
         return { actions: Flow<Action<S, A>>, getState: GetState<S> ->
             actions
-                .map { isInState(getState()) }
-                .distinctUntilChanged()
+                .mapToIsInState(isInState, getState)
                 .flatMapLatest {
                     if (it) {
                         setStateFlow(getState)


### PR DESCRIPTION
It now uses the same implementation as `onEnter` to detect entering and leaving the state.

I think we could even go further and remove the extra builder and use the `CollectInStateBasedOnStateSideEffectBuilder` also for this one. The given `Flow` can be converted into a flowBuilder like this `{ currentStateFlow -> currentStateFlow.take(1).flatMapLatest { flowPassedInByUser }`. 