### PR TITLE
Adds Effects as counterpart to existing DSL primitives

### DIFF
--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -397,6 +397,42 @@ The passed Flow (in our case the timer) is automatically canceled once the state
 triggers `on<RetryLoadingAction>` which causes a state transition to `LoadingState` or when 3 seconds have elapsed
 because then the defined `MutateState` causes a transitions to `LoadingState`.
 
+## Effects
+If you don't want to change the state but do some work without changing the state i.e. logging,
+triggering google analytics or trigger navigation then Effects is what you are looking for.
+
+The following counterparts to `on<Action>`, `onEnter` and `collectWhileInState` exists:
+- `onActionEffect<Action>`: Like `on<Action>` this triggers whenever the described Action is dispatched.
+- `onEnterEffect`: Like `onEnter` this triggers whenever you enter the state.
+- `collectWhileInStateEffect`: Like `collectWhileInState` this is used to collect a `Flow`.
+
+Effects behave the same way as their counterparts, i.e. cancelation etc. works just the same way as described in the section of `on<Action>`, `onEnter` and `collectWhileInState`.Effects
+
+Usage:
+```kotlin
+class MyStateMachine : FlowReduxStateMachine<State, Action>(initialState = LoadingState) {
+
+    init {
+        spec {
+            inState<ShowContentState> {
+               onEnterEffect { stateSnapshot ->
+                   logMessage("Did enter $state") // note there is no state change
+               }
+
+               onActionEffect<ButtonClickedAction> { action, stateSnapshot ->
+                    analyticsTracker.track(ButtonClickedEvent()) // note there is no state change
+               }
+
+               collectWhileInStateEffect(someFlow) {value, stateSnapshot ->
+                    logMessage("Collected $value from flow while in state $stateSnapshot") // note there is no state change
+               }
+            }
+
+        }
+    }
+}
+```
+
 ## Custom condition for inState
 
 We already covered `inState<State>` that builds upon the recommended best practice that every State in your state

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/EffectHandlers.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/EffectHandlers.kt
@@ -1,0 +1,5 @@
+package com.freeletics.flowredux.dsl
+
+typealias OnActionEffectHandler<InputState, A> = suspend (action: A, state: InputState) -> Unit
+typealias OnEnterStateEffectHandler<InputState> = suspend (state: InputState) -> Unit
+typealias CollectFlowEffectHandler<T, InputState> = suspend (value: T, state: InputState) -> Unit

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
@@ -87,11 +87,9 @@ class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
     inline fun <reified SubAction : A> onActionEffect(
         noinline handler: OnActionEffectHandler<InputState, SubAction>
     ) {
-        on(flatMapPolicy = FlatMapPolicy.LATEST,
-            handler = { action: SubAction, state: InputState ->
-                handler(action, state)
-                NoStateChange
-            }
+        onActionEffect(
+            flatMapPolicy = FlatMapPolicy.LATEST,
+            handler = handler
         )
     }
 

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateEffectTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateEffectTest.kt
@@ -1,0 +1,95 @@
+package com.freeletics.flowredux.dsl
+
+import app.cash.turbine.test
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.ExperimentalTime
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.flatMapConcat
+
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class, ExperimentalTime::class)
+class CollectWhileInStateEffectTest {
+
+    @Test
+    fun `collectWhileInStateEffect stops after having moved to next state`() = suspendTest {
+
+        val recordedValues = mutableListOf<Int>()
+
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                val flow = flow {
+                    emit(1)
+                    delay(10)
+                    emit(2)
+                    delay(10)
+                    emit(3)
+                }
+
+                collectWhileInStateEffect(flow) { v, _ ->
+                    recordedValues.add(v)
+                }
+
+                collectWhileInState(flow {
+                    delay(5)
+                    emit(1)
+                }) { _, _ ->
+                    OverrideState(TestState.S1)
+                }
+            }
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, awaitItem())
+            assertEquals(TestState.S1, awaitItem())
+        }
+        assertEquals(listOf(1), recordedValues) // 2,3 is not emitted
+    }
+
+
+    @Test
+    fun `collectWhileInStateEffect with flowBuilder stops after having moved to next state`() =
+        suspendTest {
+
+            val recordedValues = mutableListOf<Int>()
+
+            val sm = StateMachine {
+                inState<TestState.Initial> {
+                    collectWhileInState({
+                        it.flatMapConcat {
+                            flow {
+                                delay(7)
+                                emit(1)
+                            }
+                        }
+                    }) { _, _ ->
+                        OverrideState(TestState.S1)
+                    }
+
+                    collectWhileInStateEffect({
+                        it.flatMapConcat {
+                            flow {
+                                emit(1)
+                                delay(10)
+                                emit(2)
+                                delay(10)
+                                emit(3)
+                            }
+                        }
+                    }) { v, _ ->
+                        recordedValues.add(v)
+                    }
+                }
+
+            }
+
+            sm.state.test {
+                assertEquals(TestState.Initial, awaitItem())
+                assertEquals(TestState.S1, awaitItem())
+            }
+            assertEquals(listOf(1), recordedValues) // 2,3 is not emitted
+        }
+}

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionEffectTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionEffectTest.kt
@@ -1,0 +1,77 @@
+package com.freeletics.flowredux.dsl
+
+import app.cash.turbine.test
+import kotlinx.coroutines.delay
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.ExperimentalTime
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class, ExperimentalTime::class)
+class OnActionEffectTest {
+
+    private val delay = 200L
+
+    @Test
+    fun `action effect block stops when moved to another state`() = suspendTest {
+        var reached = false;
+        var reachedBefore = false
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                onActionEffect<TestAction.A1> { _, _ ->
+                    reachedBefore = true
+                    delay(delay)
+                    // this should never be reached because state transition did happen in the meantime,
+                    // therefore this whole block must be canceled
+                    reached = true
+                }
+
+                on<TestAction.A2> { _, _ ->
+                    OverrideState(TestState.S2)
+                }
+            }
+
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            delay(delay / 2)
+            sm.dispatchAsync(TestAction.A2)
+            assertEquals(TestState.S2, awaitItem())
+            delay(delay)
+            expectNoEvents()
+        }
+
+        assertTrue(reachedBefore)
+        assertFalse(reached)
+    }
+
+    @Test
+    fun `on action effect is triggered`() = suspendTest {
+        var effectTriggered = false
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                onActionEffect<TestAction.A1> { _, _ ->
+                    effectTriggered = true
+                }
+
+                on<TestAction.A1> { _, _ ->
+                    delay(10) // give onActionEffect a bit of time before changing state
+                    OverrideState(TestState.S2)
+                }
+            }
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, awaitItem())
+            assertFalse(effectTriggered)
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(TestState.S2, awaitItem())
+            assertTrue(effectTriggered)
+        }
+    }
+}

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterEffectTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterEffectTest.kt
@@ -1,0 +1,83 @@
+package com.freeletics.flowredux.dsl
+
+import app.cash.turbine.test
+import kotlinx.coroutines.delay
+import kotlin.time.ExperimentalTime
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlin.test.*
+
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class, ExperimentalTime::class)
+class OnEnterEffectTest {
+
+    private val delay = 200L
+
+    @Test
+    fun `onEnter effect block stops when moved to another state`() = suspendTest {
+        var reached = false;
+        var blockEntered = false
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                onEnterEffect {
+                    blockEntered = true
+                    delay(delay)
+                    // this should never be reached because state transition did happen in the meantime,
+                    // therefore this whole block must be canceled
+                    reached = true
+                    OverrideState(TestState.S1)
+                }
+
+                on<TestAction.A2> { _, _ ->
+                    OverrideState(TestState.S2)
+                }
+            }
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, awaitItem())
+            delay(delay / 2)
+            sm.dispatchAsync(TestAction.A2)
+            assertEquals(TestState.S2, awaitItem())
+            delay(delay)
+            expectNoEvents()
+        }
+
+        assertTrue(blockEntered)
+        assertFalse(reached)
+    }
+
+    @Test
+    fun `on entering the same state doesnt trigger onEnterEffect again`() = suspendTest {
+        var genericStateEffectEntered = 0
+        var a1Received = 0
+
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                onEnter {
+                    OverrideState(TestState.GenericState("from initial", 0))
+                }
+            }
+
+            inState<TestState.GenericState> {
+                onEnterEffect {
+                    genericStateEffectEntered++
+                }
+
+                on<TestAction.A1> { _, _ ->
+                    a1Received++
+                    OverrideState(TestState.GenericState("onA1", a1Received))
+                }
+            }
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, awaitItem())
+            assertEquals(TestState.GenericState("from initial", 0), awaitItem())
+            repeat(2) { index ->
+                sm.dispatch(TestAction.A1) // Causes state transition to S1 again which is already current
+                assertEquals(TestState.GenericState("onA1", index + 1), awaitItem())
+            }
+        }
+        assertEquals(1, genericStateEffectEntered)
+    }
+}


### PR DESCRIPTION
adds
- `onActionEffect<Action>` 
- `onEnterEffect`
- `collectWhileInStateEffect` 

which behave (in the sense of cancelation) the same way as their counterparts.