### PR TITLE
Add Apple Silicon targets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        mavenLocal()
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,7 +24,7 @@ ext.versions = [
 
         junit                  : '4.13.2',
         turbine                : '0.6.1',
-        kotest                 : '4.6.3',
+        kotest                 : '5.0.0.M2',
 ]
 
 ext.libraries = [

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,7 +36,7 @@ ext.libraries = [
         coroutines        : "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.coroutines",
         rxJava            : "io.reactivex.rxjava2:rxjava:$versions.rxJava",
         rxAndroid         : "io.reactivex.rxjava2:rxandroid:$versions.rxAndroid",
-        flMadStateMachine : "com.freeletics.mad:state-machine:0.3.0-SNAPSHOT",
+        flMadStateMachine : "com.freeletics.mad:state-machine:0.2.1",
 ]
 
 ext.supportLibraries = [

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
         compileSdk             : 30,
         targetSdk              : 30,
         minSdk                 : 21,
-
+        
         dokka                  : '1.5.31',
         coroutines             : '1.5.2',
         kotlin                 : '1.5.31',
@@ -36,7 +36,7 @@ ext.libraries = [
         coroutines        : "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.coroutines",
         rxJava            : "io.reactivex.rxjava2:rxjava:$versions.rxJava",
         rxAndroid         : "io.reactivex.rxjava2:rxandroid:$versions.rxAndroid",
-        flMadStateMachine : "com.freeletics.mad:state-machine:0.2.0",
+        flMadStateMachine : "com.freeletics.mad:state-machine:0.3.0-SNAPSHOT",
 ]
 
 ext.supportLibraries = [

--- a/dsl/build.gradle
+++ b/dsl/build.gradle
@@ -13,14 +13,18 @@ kotlin {
     iosArm32()
     iosArm64()
     iosX64()
+    iosSimulatorArm64()
     linuxX64()
     macosX64()
+    macosArm64()
     mingwX64()
     tvosArm64()
     tvosX64()
+    tvosSimulatorArm64()
     watchosArm32()
     watchosArm64()
     watchosX86()
+    watchosSimulatorArm64()
 
     sourceSets {
         commonMain {
@@ -61,14 +65,18 @@ kotlin {
                 targets.iosArm32,
                 targets.iosArm64,
                 targets.iosX64,
+                targets.iosSimulatorArm64,
                 targets.linuxX64,
                 targets.macosX64,
+                targets.macosArm64,
                 targets.mingwX64,
                 targets.tvosArm64,
                 targets.tvosX64,
+                targets.tvosSimulatorArm64,
                 targets.watchosArm32,
                 targets.watchosArm64,
                 targets.watchosX86,
+                targets.watchosSimulatorArm64,
         ]) {
             compilations.main.source(sourceSets.nativeMain)
             compilations.test.source(sourceSets.nativeTest)

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/InStateSideEffectBuilder.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/InStateSideEffectBuilder.kt
@@ -2,6 +2,8 @@ package com.freeletics.flowredux.dsl.internal
 
 import com.freeletics.flowredux.GetState
 import com.freeletics.flowredux.SideEffect
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 
 /**
  * It's just not an Interface to not expose internal class `Action` to the public.
@@ -9,6 +11,8 @@ import com.freeletics.flowredux.SideEffect
  */
 // TODO verify if this should be internal.
 abstract class InStateSideEffectBuilder<InputState : S, S, A> internal constructor() {
+    @ExperimentalCoroutinesApi
+    @FlowPreview
     internal abstract fun generateSideEffect(): SideEffect<S, Action<S, A>>
 
 

--- a/flowredux/build.gradle
+++ b/flowredux/build.gradle
@@ -13,14 +13,18 @@ kotlin {
     iosArm32()
     iosArm64()
     iosX64()
+    iosSimulatorArm64()
     linuxX64()
     macosX64()
+    macosArm64()
     mingwX64()
     tvosArm64()
     tvosX64()
+    tvosSimulatorArm64()
     watchosArm32()
     watchosArm64()
     watchosX86()
+    watchosSimulatorArm64()
 
     sourceSets {
         commonMain {
@@ -61,14 +65,18 @@ kotlin {
                 targets.iosArm32,
                 targets.iosArm64,
                 targets.iosX64,
+                targets.iosSimulatorArm64,
                 targets.linuxX64,
                 targets.macosX64,
+                targets.macosArm64,
                 targets.mingwX64,
                 targets.tvosArm64,
                 targets.tvosX64,
+                targets.tvosSimulatorArm64,
                 targets.watchosArm32,
                 targets.watchosArm64,
                 targets.watchosX86,
+                targets.watchosSimulatorArm64,
         ]) {
             compilations.main.source(sourceSets.nativeMain)
             compilations.test.source(sourceSets.nativeTest)


### PR DESCRIPTION
Fixes #199.

Temporarily using`com.freeletics.mad:state-machine:0.3.0-SNAPSHOT` (testing locally) until [this](https://github.com/freeletics/mad/pull/11) merged and released.

Remaining dependencies missing apple silicon targets:
- [x] kotest
- [x] turbine