### PR TITLE
fix crash in flowBuilder based collectWhileInState

### DIFF
--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CollectInStateBasedOnStateSideEffectBuilder.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CollectInStateBasedOnStateSideEffectBuilder.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 
 /**
  * A builder to create a [SideEffect] that observes a Flow<T> as long as the redux store is in
@@ -43,7 +43,7 @@ internal class CollectInStateBasedOnStateBuilder<T, InputState : S, S : Any, A :
     private fun flowOfCurrentState(actions: Flow<Action<S, A>>, getState: GetState<S>): Flow<InputState> {
         // after every state change there is a guaranteed action emission so we use this 
         // to get the current state
-        return actions.map { getState() as InputState }
+        return actions.mapNotNull { getState() as? InputState }
             // an action emission does not guarantee that the state changed so we need to filter
             // out multiple emissions of identical state objects    
             .distinctUntilChanged()


### PR DESCRIPTION
I can't reproduce it in tests but it happened a few times in a state machine that is very busy (multiple actions per second) after some time. I assume there are cases where the state changes right before the flow reaches map. Using a safe cast with mapNotNull here should be fine as any change state would no-op anyways because of later state checks.

In general this is probably another reason to rethink the internals and make state changes more of a primary thing instead of having it purely based on action emissions that happen afterwards