### PR TITLE
Make FlowReduxStateMachine "cold" again

### DIFF
--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
@@ -6,51 +6,66 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.isActive
 
 @FlowPreview
 @ExperimentalCoroutinesApi
 abstract class FlowReduxStateMachine<S : Any, A : Any>(
-    private val initialState: S,
-    private val scope: CoroutineScope,
+    private val initialStateSupplier: () -> S,
     private val logger: FlowReduxLogger? = null
-) : StateMachine<S, A> {
+) {
 
     private val inputActions = Channel<A>()
-    private var internalState: StateFlow<S>? = null
+    private var specBlock: (FlowReduxStoreBuilder<S, A>.() -> Unit)? = null
+    private var specBlockSet = false
+
+    constructor(
+        initialStateSupplier: () -> S
+    ) : this(
+        logger = null,
+        initialStateSupplier = initialStateSupplier
+    )
+
+    constructor(initialState: S) : this(logger = null, initialState = initialState)
+
+    constructor(
+        initialState: S,
+        logger: FlowReduxLogger?
+    ) : this(logger = logger, initialStateSupplier = { initialState })
 
     protected fun spec(specBlock: FlowReduxStoreBuilder<S, A>.() -> Unit) {
-        if (internalState != null) {
+
+        if (this.specBlock != null)
             throw IllegalStateException(
                 "State machine spec has already been set. " +
-                    "It's only allowed to call spec {...} once."
+                        "It's only allowed to call spec {...} once."
             )
-        }
-        internalState = inputActions
-            .consumeAsFlow()
-            .reduxStore(logger, initialState, specBlock)
-            .stateIn(scope, SharingStarted.Lazily, initialState)
+
+        this.specBlock = specBlock
+        this.specBlockSet = true
+
     }
 
-    override val state: StateFlow<S> get() {
-        check(scope.isActive) { "The scope of this state machine was already cancelled." }
+    val state: Flow<S> by lazy(LazyThreadSafetyMode.NONE) {
         checkSpecBlockSet()
-        return internalState!!
+        inputActions
+            .consumeAsFlow()
+            .reduxStore(logger, initialStateSupplier, specBlock!!)
+            .also {
+                specBlock = null // Free up memory
+            }
     }
 
-    override suspend fun dispatch(action: A) {
-        check(scope.isActive) { "The scope of this state machine was already cancelled." }
+    suspend fun dispatch(action: A) {
+        checkSpecBlockSet()
         inputActions.send(action)
     }
 
     private fun checkSpecBlockSet() {
-       if (internalState == null) {
-           throw IllegalStateException(
-               """
+        if (!specBlockSet) {
+            throw IllegalStateException(
+                """
                     No state machine specs are defined. Did you call spec { ... } in init {...}?
                     Example usage:
 
@@ -66,7 +81,7 @@ abstract class FlowReduxStateMachine<S : Any, A : Any>(
                         }
                     }
                 """.trimIndent()
-           )
-       }
+            )
+        }
     }
 }

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachineTest.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachineTest.kt
@@ -26,7 +26,7 @@ class FlowReduxStateMachineTest {
     @Test
     fun `calling spec block twice throws exception`() {
 
-        val sm = object : FlowReduxStateMachine<Any, Any>(Any(), CoroutineScope(EmptyCoroutineContext)) {
+        val sm = object : FlowReduxStateMachine<Any, Any>(Any()) {
 
             init {
                 spec { }
@@ -50,7 +50,7 @@ class FlowReduxStateMachineTest {
     @Test
     fun `no spec block set throws exception`() {
 
-        val sm = object : FlowReduxStateMachine<Any, Any>(Any(), CoroutineScope(EmptyCoroutineContext)) {}
+        val sm = object : FlowReduxStateMachine<Any, Any>(Any()) {}
 
         try {
             sm.state

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/StateMachine.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/StateMachine.kt
@@ -1,40 +1,28 @@
 package com.freeletics.flowredux.dsl
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 fun StateMachine(
-        builderBlock: FlowReduxStoreBuilder<TestState, TestAction>.() -> Unit
+    builderBlock: FlowReduxStoreBuilder<TestState, TestAction>.() -> Unit
 ): TestStateMachine {
     return TestStateMachine(builderBlock)
 }
+
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
-class TestStateMachine  constructor(
-    val specBlock: FlowReduxStoreBuilder<TestState, TestAction>.() -> Unit
+class TestStateMachine constructor(
+    specBlock: FlowReduxStoreBuilder<TestState, TestAction>.() -> Unit
+) : FlowReduxStateMachine<TestState, TestAction>(
+    logger = CommandLineLogger,
+    initialState = TestState.Initial
 ) {
 
-    private val inputActions = Channel<TestAction>()
-
-    val state: Flow<TestState>
-        get() {
-        return inputActions
-            .consumeAsFlow()
-            .reduxStore(CommandLineLogger, TestState.Initial, specBlock)
-            .flowOn(Dispatchers.Default)
-        }
-
-    suspend fun dispatch(action: TestAction) {
-        inputActions.send(action)
+    init {
+        spec(specBlock)
     }
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/StateMachine.kt
+++ b/dsl/src/commonTest/kotlin/com/freeletics/flowredux/dsl/StateMachine.kt
@@ -7,14 +7,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
-fun StateMachine(
-    builderBlock: FlowReduxStoreBuilder<TestState, TestAction>.() -> Unit
-): TestStateMachine {
-    return TestStateMachine(builderBlock)
-}
-
-@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
-class TestStateMachine constructor(
+class StateMachine constructor(
     specBlock: FlowReduxStoreBuilder<TestState, TestAction>.() -> Unit
 ) : FlowReduxStateMachine<TestState, TestAction>(
     logger = CommandLineLogger,

--- a/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux/sample/shared/PaginationStateMachine.kt
+++ b/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux/sample/shared/PaginationStateMachine.kt
@@ -74,10 +74,9 @@ data class ShowContentAndLoadingNextPageErrorPaginationState(
 ) : ContainsContentPaginationState()
 
 internal class InternalPaginationStateMachine(
-    scope: CoroutineScope,
     logger: FlowReduxLogger,
     private val githubApi: GithubApi
-) : FlowReduxStateMachine<PaginationState, Action>(LoadFirstPagePaginationState, scope, logger) {
+) : FlowReduxStateMachine<PaginationState, Action>(LoadFirstPagePaginationState, logger) {
     init {
         spec {
 
@@ -208,7 +207,6 @@ class PaginationStateMachine(
     private val scope: CoroutineScope
 ) {
     private val stateMachine = InternalPaginationStateMachine(
-        scope = scope,
         logger = logger,
         githubApi = githubApi
     )


### PR DESCRIPTION
Fixes #210 .

Removes `StateFlow` and the need to pass a `Scope` as constructor parameter of `FlowReduxStateMachine` in.

Also I have removed temporarily the inherintance to Freeletics MAD `StateMachine` because `StateMachine` still requires a `val state : StateFlow<S>` . Let's discuss how to proceed here, but I'm happy to create a PR to Freeletics MAD repo as well. 


It should also fix #204 .