### PR TITLE
publish everything from macOS

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,14 +7,7 @@ on:
 
 jobs:
   publish:
-
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
-      # run sequentially to avoid conflicts for closeAndReleaseRepository
-      max-parallel: 1
-
-    runs-on: ${{matrix.os}}
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
@@ -27,20 +20,12 @@ jobs:
 
       - name: Install Android SDK
         run: ./.github/android-sdk.sh
-        if: matrix.os == 'macos-latest'
+
+      - name: Build release
+        run: ./gradlew assemble
 
       - name: Upload release
         run: ./gradlew publish --no-daemon --no-parallel
-        if: matrix.os == 'macos-latest'
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
-
-      - name: Upload release (Windows)
-        run: ./gradlew publishMingwX64PublicationToMavenCentralRepository --no-daemon --no-parallel
-        if: matrix.os == 'windows-latest'
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -7,12 +7,7 @@ on:
 
 jobs:
   publish:
-
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
-
-    runs-on: ${{matrix.os}}
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
@@ -25,7 +20,6 @@ jobs:
 
       - name: Install Android SDK
         run: ./.github/android-sdk.sh
-        if: matrix.os == 'macos-latest'
 
       - name: Retrieve version
         run: |
@@ -34,16 +28,6 @@ jobs:
 
       - name: Publish snapshot
         run: ./gradlew publish --no-daemon --no-parallel
-        if: ${{ endsWith(env.VERSION_NAME, '-SNAPSHOT') && matrix.os == 'macos-latest' }}
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
-
-      - name: Publish snapshot (Windows)
-        run: ./gradlew publishMingwX64PublicationToMavenCentralRepository --no-daemon --no-parallel
-        if: ${{ endsWith(env.VERSION_NAME, '-SNAPSHOT') && matrix.os == 'windows-latest' }}
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
With Kotlin 1.6.0 it's possible to build the windows artifacts on macOS so we can build everything there for publishing. 