### PR TITLE
remove obsolete experimental annotations

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/FlowRedux.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/FlowRedux.kt
@@ -1,6 +1,5 @@
 package com.freeletics.flowredux
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
@@ -30,7 +29,6 @@ fun <A, S> Flow<A>.reduxStore(
  * Creates a Redux store with a [initialStateSupplier] that produces the first state lazily once
  * the flow starts.
  */
-@ExperimentalCoroutinesApi
 internal fun <A, S> Flow<A>.reduxStore(
     initialStateSupplier: () -> S,
     sideEffects: Iterable<SideEffect<S, A>>,

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/flow/WhileInState.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/flow/WhileInState.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
 
-@ExperimentalCoroutinesApi
 internal fun <S, A> Flow<Action<S, A>>.whileInState(
     isInState: (S) -> Boolean,
     getState: GetState<S>,

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/InStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/InStateSideEffectBuilder.kt
@@ -11,8 +11,6 @@ import kotlinx.coroutines.FlowPreview
  */
 internal abstract class InStateSideEffectBuilder<InputState : S, S, A> {
 
-    @ExperimentalCoroutinesApi
-    @FlowPreview
     internal abstract fun generateSideEffect(): SideEffect<S, Action<S, A>>
 
     internal suspend inline fun runOnlyIfInInputState(


### PR DESCRIPTION
At least a few methods don't need it anymore. The main reasons why we still need them for most parts of the code are the various `flatMap*` variations. At least `flatMapLatest` could also go stable soon though https://github.com/Kotlin/kotlinx.coroutines/issues/3168