### PR TITLE
introduce currentState in FlowReduxStateMachine

### DIFF
--- a/compose/src/main/java/com/freeletics/flowredux/compose/ComposeFlowReduxStateMachine.kt
+++ b/compose/src/main/java/com/freeletics/flowredux/compose/ComposeFlowReduxStateMachine.kt
@@ -1,10 +1,13 @@
 package com.freeletics.flowredux.compose
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import com.freeletics.flowredux.dsl.FlowReduxStateMachine
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 
@@ -15,7 +18,8 @@ import kotlinx.coroutines.launch
 @FlowPreview
 @Composable
 public fun <S : Any, A : Any> FlowReduxStateMachine<S, A>.rememberState(): State<S> {
-    return produceState(initialValue = this.initialState, this) {
+    val (state, initialState) = remember { stateAndInitialState() }
+    return produceState(initialValue = initialState, this) {
         state.drop(1) // skip the first one as it is the initial state which is already submitted with produceState's initial state
             .collect { value = it }
     }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
@@ -35,15 +35,3 @@ internal fun <S : Any, A : Any> Flow<A>.reduxStore(
         )
         .distinctUntilChanged { old, new -> old === new } // distinct until not the same object reference.
 }
-
-/**
- * Provides a fluent DSL to specify a ReduxStore
- */
-@FlowPreview
-@ExperimentalCoroutinesApi
-public fun <S : Any, A : Any> Flow<A>.reduxStore(
-    initialState: S,
-    block: FlowReduxStoreBuilder<S, A>.() -> Unit
-): Flow<S> =
-    this.reduxStore(initialStateSupplier = { initialState }, block = block)
-

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/SubStateMachineTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/SubStateMachineTest.kt
@@ -270,15 +270,17 @@ class SubStateMachineTest {
             var parentS2 = 0
             var childFactory = 0
 
-            val child = ChildStateMachine(initialState = TestState.S2) {
-                inState<TestState.S2> {
-                    onEnter {
-                        childOnEnterS2++
-                        NoStateChange
-                    }
-                    on<TestAction.A2> { _, _ ->
-                        childActionA2++
-                        OverrideState(TestState.S1)
+            val createChild = {
+                ChildStateMachine(initialState = TestState.S2) {
+                    inState<TestState.S2> {
+                        onEnter {
+                            childOnEnterS2++
+                            NoStateChange
+                        }
+                        on<TestAction.A2> { _, _ ->
+                            childActionA2++
+                            OverrideState(TestState.S1)
+                        }
                     }
                 }
             }
@@ -290,7 +292,7 @@ class SubStateMachineTest {
                 inState<TestState.S2> {
                     onEnterEffect { parentS2++ }
                     stateMachine(
-                        stateMachineFactory = { childFactory++; child },
+                        stateMachineFactory = { childFactory++; createChild() },
                         actionMapper = { it },
                         stateMapper = { _, childState -> OverrideState(childState) }
                     )


### PR DESCRIPTION
When the compose artifact was introduced we started keeping `initialState` in an internal variable inside of `FlowReduxStateMachine` even if we passed in an `initialStateSupplier`. This has the issue that whenever you start collecting the state machine again you will start from what `initialStateSupplier` returned when you first started collecting. This means that you can't for example safe the state and then restore it in the supplier. It doesn't just affect configuration changes, it also happens for example if you use Fragments navigate to another one and then go back. 

What this does is that it introduces an internal `currentState` variable that is updated from an `onEach`. Whenever we build a state flow we will use `currentState` if available and only fallback to `initialState` if it's not. There is a new `stateAndInitialState` method that returns the `state` together with what will be the initial state of that `Flow` (modeled after `StateAndDispatch`). I didn't want to make `currentState` itself public because it would enable bad state machine implementations that try to read it.

This has one effect on child state machines. If you re-use the same instance of a child state machine when leaving and re-entering that child state it will behave differently because it still has the old `currentState`. If the child state machine left the state it's supposed to operate in, it's effectively dead because it will never re-enter the state. You can see that in the updated test, the child state machine will forever stay in `S1` after the first loop. Personally I think this change is fine because you'd probably construct a new sub state machine each time and pass the parent state to it, but maybe there is a use case I'm not considering.