### PR TITLE
Removed initial state and use `null` as initial state in compose

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/Dsl.kt
@@ -35,15 +35,3 @@ internal fun <S : Any, A : Any> Flow<A>.reduxStore(
         )
         .distinctUntilChanged { old, new -> old === new } // distinct until not the same object reference.
 }
-
-/**
- * Provides a fluent DSL to specify a ReduxStore
- */
-@FlowPreview
-@ExperimentalCoroutinesApi
-public fun <S : Any, A : Any> Flow<A>.reduxStore(
-    initialState: S,
-    block: FlowReduxStoreBuilder<S, A>.() -> Unit
-): Flow<S> =
-    this.reduxStore(initialStateSupplier = { initialState }, block = block)
-

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
@@ -13,10 +13,8 @@ import kotlinx.coroutines.flow.receiveAsFlow
 @FlowPreview
 @ExperimentalCoroutinesApi
 public abstract class FlowReduxStateMachine<S : Any, A : Any>(
-    initialStateSupplier: () -> S,
+    private val initialStateSupplier: () -> S,
 ) : StateMachine<S, A> {
-
-    public val initialState: S by lazy(LazyThreadSafetyMode.NONE, initialStateSupplier)
 
     private val inputActions = Channel<A>()
     private lateinit var outputState: Flow<S>
@@ -35,7 +33,7 @@ public abstract class FlowReduxStateMachine<S : Any, A : Any>(
 
         outputState = inputActions
             .receiveAsFlow()
-            .reduxStore(initialState, specBlock)
+            .reduxStore(initialStateSupplier, specBlock)
             .onStart {
                 activeFlowCounter.incrementAndGet()
             }

--- a/sample/android/src/main/java/com/freeletics/flowredux/compose/ComposeActivity.kt
+++ b/sample/android/src/main/java/com/freeletics/flowredux/compose/ComposeActivity.kt
@@ -14,10 +14,7 @@ class ComposeActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             val (state, dispatch) = stateMachine.rememberStateAndDispatch()
-            val stateValue = state.value
-            if (stateValue != null) {
-                PopularRepositoriesUi(stateValue, dispatch)
-            }
+            PopularRepositoriesUi(state.value, dispatch)
         }
     }
 }

--- a/sample/android/src/main/java/com/freeletics/flowredux/compose/ComposeActivity.kt
+++ b/sample/android/src/main/java/com/freeletics/flowredux/compose/ComposeActivity.kt
@@ -14,7 +14,10 @@ class ComposeActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             val (state, dispatch) = stateMachine.rememberStateAndDispatch()
-            PopularRepositoriesUi(state.value, dispatch)
+            val stateValue = state.value
+            if (stateValue != null) {
+                PopularRepositoriesUi(stateValue, dispatch)
+            }
         }
     }
 }

--- a/sample/android/src/main/java/com/freeletics/flowredux/compose/PopularRepositoriesUi.kt
+++ b/sample/android/src/main/java/com/freeletics/flowredux/compose/PopularRepositoriesUi.kt
@@ -11,11 +11,12 @@ import com.freeletics.flowredux.sample.shared.*
 import kotlinx.coroutines.launch
 
 @Composable
-fun PopularRepositoriesUi(state : PaginationState, dispatch: (Action) -> Unit) {
+fun PopularRepositoriesUi(state: PaginationState?, dispatch: (Action) -> Unit) {
     val scaffoldState = rememberScaffoldState()
     SampleTheme {
         Scaffold(scaffoldState = scaffoldState) {
             when (state) {
+                null, // null means state machine did not emit yet the first state --> in mean time show Loading
                 is LoadFirstPagePaginationState -> LoadingUi()
                 is LoadingFirstPageError -> ErrorUi(dispatch)
                 is ContainsContentPaginationState -> {
@@ -37,10 +38,10 @@ fun PopularRepositoriesUi(state : PaginationState, dispatch: (Action) -> Unit) {
                     }
                 }
             }
+
         }
     }
 }
-
 
 private fun ContainsContentPaginationState.shouldShowLoadMoreIndicator(): Boolean = when (this) {
     is ShowContentPaginationState -> false


### PR DESCRIPTION
As discussed in #279 :
- removing initial state from state machine. Maybe we can find some middle ground in the future between #279 and this PR but I think for now it is best to make it "predictable" and simplified by removing this.
- Uses `null` as initial state for `produceState() ` i.e. used by `rememberState()` and `rememberStateAndDispatch()`. I have mixed feelings about it. On one hand I don't like working with `null` too much and would prefer usually something more descriptive, but on the other hand introducing some linke sealed interface just to be more descriptive seems like an overkill to me. I played around in my head with something like this: 
```kotlin
public sealed interface FlowReduxState<S : Any>

/**
 * Indicates that no state has been emitted by the [FlowReduxStateMachine] yet.
 */
public object NoStateYet : FlowReduxState<Nothing>

@JvmInline
public value class CollectedState<S : Any>(private val internalState : Any) : FlowReduxState<S>{
    public fun  state() : S = internalState as S
}
```

(Btw. apparently Generics don't work directly with inline classes that is why I worked around it with `fun state()` and casting that made it even worse 😄  for the consumer of this library). 

Unless someone sees an issue, I would go for now with `null`.  