### PR TITLE
don't swallow ClassCastExceptions from the handler

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/InStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/InStateSideEffectBuilder.kt
@@ -20,16 +20,18 @@ internal abstract class InStateSideEffectBuilder<InputState : S, S, A> {
         val currentState = getState()
         // only start if is in state condition is still true
         if (isInState(currentState)) {
-            try {
+            val inputState = try {
                 @Suppress("UNCHECKED_CAST")
-                val inputState = currentState as InputState
-                block(inputState)
+                currentState as InputState
             } catch (e: ClassCastException) {
                 // it is ok to to swallow the exception as if there is a typecast exception,
                 // then a state transition did happen between triggering this side effect (isInState condition)
                 // and actually executing this block. This is an expected behavior as it can happen in a
                 // concurrent state machine. Therefore just ignoring it is fine.
+                return
             }
+
+            block(inputState)
         }
     }
 }


### PR DESCRIPTION
Reduces the scope of our try/catch to just the casting of `currentState` to avoid that actual issues with the call to `block` are swallowed. Real world case that happened to us: We have a `Flow<Foo>` to which we emit `Foo` after reading it as `Parcelable` from a `Bundle`. However the function that reads and emits `Foo` is actually generic so it's just operating with a `T : Parcelable`. Because of type erasure there is no type check happening here so whatever parcelable is in the bundle will be emitted, even if it is not `Foo`. When the `Flow` then has no other transform and is used directly with `collectWhileInState` the first type check happens when our handler is called which expects `Foo` as parameter. This happens inside `block` so the `ClassCastException` there is swallowed. From a developer side this then looks like there being no emissions or FlowRedux not working correctly. In our case we accidentally put the wrong parcelable into the bundle and it had a very similar name so we didn't notice, it took me a long time to debug this inside flow redux to fire out the issue.