### PR TITLE
publish snapshots from all branches and prs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,13 +7,14 @@ on:
 
 jobs:
   publish:
+
     runs-on: macos-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install JDK 11
+      - name: Install JDK
         uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -21,8 +22,12 @@ jobs:
       - name: Install Android SDK
         run: ./.github/android-sdk.sh
 
-      - name: Build release
-        run: ./gradlew assemble
+      # publish to local repository so that everything can be built in parallel
+      - name: Publish locally
+        run: ./gradlew publishToMavenLocal
+        env:
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
 
       - name: Upload release
         run: ./gradlew publish --no-daemon --no-parallel

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -3,17 +3,19 @@ name: Publish Snapshot
 on:
   push:
     branches:
-      - main
+      - '**'
+  pull_request:
 
 jobs:
   publish:
+
     runs-on: macos-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install JDK 11
+      - name: Install JDK
         uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -21,13 +23,18 @@ jobs:
       - name: Install Android SDK
         run: ./.github/android-sdk.sh
 
-      - name: Retrieve version
+      - name: Set version for branch
+        if: github.event_name != 'pull_request'
         run: |
-          echo "VERSION_NAME=$(cat gradle.properties | grep -w "VERSION_NAME" | cut -d'=' -f2)" >> $GITHUB_ENV
-        shell: bash
+          echo "ORG_GRADLE_PROJECT_VERSION_NAME=${{ github.ref_name }}-SNAPSHOT" >> $GITHUB_ENV
+
+      - name: Set version for pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "ORG_GRADLE_PROJECT_VERSION_NAME=pr${{ github.event.number }}-SNAPSHOT" >> $GITHUB_ENV
 
       - name: Publish snapshot
-        run: ./gradlew publish --no-daemon --no-parallel
+        run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -24,7 +24,7 @@ jobs:
         run: ./.github/android-sdk.sh
 
       - name: Set version for branch
-        if: github.event_name != 'pull_request'
+        if: ${{ github.event_name != 'pull_request' && github.ref_name != 'main' }}
         run: |
           echo "ORG_GRADLE_PROJECT_VERSION_NAME=${{ github.ref_name }}-SNAPSHOT" >> $GITHUB_ENV
 


### PR DESCRIPTION
Makes trying out things from easier by not just using `main` for snapshots. The naming scheme is `[branch]-SNAPSHOT` (so main publishes `main-SNAPSHOT`) and `pr[pull request number]-SNAPSHOT`.