### PR TITLE
fix broken dokka

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
         compileSdk             : 31,
         targetSdk              : 31,
         minSdk                 : 21,
-        dokka                  : '1.6.21',
+        dokka                  : '1.6.10',
         coroutines             : '1.6.2',
         kotlin                 : '1.6.10',
         rxJava                 : '2.2.21',


### PR DESCRIPTION
AGP depends on an old version of Dokka which causes this incompatibility. Downgrade dokka for now until AGP 7.3.0 fixes it.