### PR TITLE
make reduce public for testing purposes

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/ChangeState.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/ChangeState.kt
@@ -57,7 +57,10 @@ public object NoStateChange : ChangeState<Nothing>()
 //TODO rename after removing deprecated NoStateChange
 internal object InternalNoStateChange : ChangeState<Nothing>()
 
-internal fun <S> ChangeState<S>.reduce(state: S): S {
+/**
+ * Transforms the given [state] according to [ChangeState] and returns the new [S].
+ */
+public fun <S> ChangeState<S>.reduce(state: S): S {
     return when (val change = this) {
         is @Suppress("deprecation") OverrideState -> change.newState
         is InternalOverrideState -> change.newState


### PR DESCRIPTION
I tried to create the `abstract fun reduce` directly in `ChangeState<out S>` but that won't work with the `out`. Removing that would mean that you can't return a more concrete `ChangeState<SubState>` anymore and adding the `out` to the lambdas (`(...) -> ChangeState<out S>`) leads to other compiler issues. So I went with just making the extension public. It was probably public before and I might have changed to internal without considering testing when introducing the explicit visibilty