### PR TITLE
Do not publish SNAPSHOT on PR events

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -3,8 +3,7 @@ name: Publish Snapshot
 on:
   push:
     branches:
-      - '**'
-  pull_request:
+      - "**"
 
 jobs:
   publish:


### PR DESCRIPTION
Ideally you should publish `-SNAPSHOT` versions only on push to `main`. I'm removing the `pull_request` event as it letting #342 fail. Ideally it should also be changed to:

```
  push:
    branches:
      - "main"
```