### PR TITLE
skip publishing snapshots when secrets are not available

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   publish:
-    if: ${{ github.actor != 'dependabot[bot]' }}
-
     runs-on: macos-latest
 
     steps:
@@ -41,3 +39,4 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
+        if: "${{ env.ORG_GRADLE_PROJECT_mavenCentralUsername != '' }}"


### PR DESCRIPTION
Will test that this actually works with one of the open dependabot prs