### PR TITLE
lint: replaced if/throw in favour of check{}

### DIFF
--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -78,7 +78,7 @@ In our example we start with the `Loading` state.
 ```kotlin
 class ItemListStateMachine(
     private val httpClient: HttpClient
-) : <ListState, Action>(initialState = Loading) {
+) : FlowReduxStateMachine<ListState, Action>(initialState = Loading) {
 
     init {
         spec {
@@ -100,7 +100,7 @@ The first concept of the DSL we learn is `inState`:
 ```kotlin
 class ItemListStateMachine(
     private val httpClient: HttpClient
-) : <ListState, Action>(initialState = Loading) {
+) : FlowReduxStateMachine<ListState, Action>(initialState = Loading) {
 
     init {
         spec {
@@ -132,7 +132,7 @@ Let's specify that with the DSL in our state machine:
 ```kotlin
 class ItemListStateMachine(
     private val httpClient: HttpClient
-) : <ListState, Action>(initialState = Loading) {
+) : FlowReduxStateMachine<ListState, Action>(initialState = Loading) {
 
     init {
         spec {
@@ -272,7 +272,7 @@ Let's extend our `ItemListStateMachine` to react on such an action:
 ```kotlin
 class ItemListStateMachine(
     private val httpClient: HttpClient
-) : <ListState, Action>(initialState = Loading) {
+) : FlowReduxStateMachine<ListState, Action>(initialState = Loading) {
 
     init {
         spec {
@@ -346,7 +346,7 @@ Now let's add some countdown capabilities to our state machine by using `collect
 ```kotlin
 class ItemListStateMachine(
     private val httpClient: HttpClient
-) : <ListState, Action>(initialState = Loading) {
+) : FlowReduxStateMachine<ListState, Action>(initialState = Loading) {
 
     init {
         spec {
@@ -427,7 +427,7 @@ For example cancelation etc. works just the same way as described in the section
 
 Usage:
 ```kotlin
-class ItemListStateMachine : ListState, Action>(initialState = Loading) {
+class ItemListStateMachine : FlowReduxStateMachine<ListState, Action>(initialState = Loading) {
 
     init {
         spec {
@@ -480,7 +480,7 @@ Given the state from above, what we  can do now with our DSL is the following:
 ```kotlin
 class ItemListStateMachine(
     private val httpClient: HttpClient
-) : <ListState, Action>(
+) : FlowReduxStateMachine<ListState, Action>(
     initialState = State(
         loading = true,
         items = emptyList(),
@@ -651,7 +651,7 @@ Let' take a look at our example state machine:
 ```kotlin
 class ItemListStateMachine(
     private val httpClient: HttpClient
-) : <ListState, Action>(initialState = Loading) {
+) : FlowReduxStateMachine<ListState, Action>(initialState = Loading) {
 
     init {
         spec {

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
@@ -31,11 +31,9 @@ public abstract class FlowReduxStateMachine<S : Any, A : Any>(
     public constructor(initialState: S) : this(initialStateSupplier = { initialState })
 
     protected fun spec(specBlock: FlowReduxStoreBuilder<S, A>.() -> Unit) {
-        if (::outputState.isInitialized) {
-            throw IllegalStateException(
-                "State machine spec has already been set. " +
+        check(!::outputState.isInitialized) {
+            "State machine spec has already been set. " +
                     "It's only allowed to call spec {...} once."
-            )
         }
 
         val sideEffects = FlowReduxStoreBuilder<S, A>().apply(specBlock).generateSideEffects()
@@ -49,12 +47,10 @@ public abstract class FlowReduxStateMachine<S : Any, A : Any>(
             .reduxStore(initialStateSupplier, sideEffects, ::reducer)
             .distinctUntilChanged { old, new -> old === new } // distinct until not the same object reference.
             .onStart {
-                if (activeFlowCounter.incrementAndGet() > 1) {
-                    throw IllegalStateException(
-                        "Can not collect state more than once at the same time. Make sure the" +
+                check(activeFlowCounter.incrementAndGet() < 1) {
+                    "Can not collect state more than once at the same time. Make sure the" +
                             "previous collection is cancelled before starting a new one. " +
                             "Collecting state in parallel would lead to subtle bugs."
-                    )
                 }
             }
             .onCompletion {
@@ -70,20 +66,17 @@ public abstract class FlowReduxStateMachine<S : Any, A : Any>(
 
     override suspend fun dispatch(action: A) {
         checkSpecBlockSet()
-        if (activeFlowCounter.get() <= 0) {
-            throw IllegalStateException(
-                "Cannot dispatch action $action because state Flow of this " +
+        check(activeFlowCounter.get() > 0) {
+            "Cannot dispatch action $action because state Flow of this " +
                     "FlowReduxStateMachine is not collected yet. " +
                     "Start collecting the state Flow before dispatching any action."
-            )
         }
         inputActions.send(action)
     }
 
     private fun checkSpecBlockSet() {
-        if (!::outputState.isInitialized) {
-            throw IllegalStateException(
-                """
+        check(::outputState.isInitialized) {
+            """
                     No state machine specs are defined. Did you call spec { ... } in init {...}?
                     Example usage:
 
@@ -99,7 +92,6 @@ public abstract class FlowReduxStateMachine<S : Any, A : Any>(
                         }
                     }
                 """.trimIndent()
-            )
         }
     }
 }


### PR DESCRIPTION
It makes the code a bit more readable, `check {}` throws anyway `IllegalStateException` as before.

https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/check.html