### PR TITLE
make methods with KClass parameter internal with @PublishedApi

### DIFF
--- a/flowredux/api/flowredux.api
+++ b/flowredux/api/flowredux.api
@@ -26,7 +26,7 @@ public abstract class com/freeletics/flowredux/dsl/FlowReduxStateMachine : com/f
 
 public final class com/freeletics/flowredux/dsl/FlowReduxStoreBuilder {
 	public fun <init> ()V
-	public final synthetic fun inState (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public final fun inState (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 	public final fun inState (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public final fun inStateWithCondition (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/ChangedState.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/ChangedState.kt
@@ -4,7 +4,7 @@ package com.freeletics.flowredux.dsl
  * Represents a state transition. Instances of this a created through the [State.mutate],
  * [State.override] and [State.noChange] methods.
  *
- * [ChangedState] doesnt allow you to directly access any property.
+ * [ChangedState] does not allow you to directly access any property.
  * Then you may wonder how do you write unit test for one of your functions that return a [ChangedState]?
  * You need to call [ChangedState.reduce] to get the actual result of the change state.
  */

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStoreBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStoreBuilder.kt
@@ -28,8 +28,8 @@ public class FlowReduxStoreBuilder<S : Any, A : Any> {
      * Define what happens if the store is in a certain state.
      * "In a certain state" condition is true if state is instance of the type specified as generic function parameter.
      */
-    @JvmSynthetic
-    public fun <SubState : S> inState(
+    @PublishedApi
+    internal fun <SubState : S> inState(
         subStateClass: KClass<SubState>,
         block: InStateBuilderBlock<SubState, S, A>.() -> Unit
     ) {
@@ -60,7 +60,8 @@ public class FlowReduxStoreBuilder<S : Any, A : Any> {
      * and additionally can specify and ADDITIONAL condition that also must be true in addition to the check that
      * the type as specified as generic fun parameter is an instance of the current state.
      */
-    public fun <SubState : S> inState(
+    @PublishedApi
+    internal  fun <SubState : S> inState(
         subStateClass: KClass<SubState>,
         additionalIsInState: (SubState) -> Boolean,
         block: InStateBuilderBlock<SubState, S, A>.() -> Unit

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
@@ -51,7 +51,8 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
      * determine the behavior when a new [SubAction] is dispatched while the previous [handler]
      * execution is still ongoing.
      */
-    public fun <SubAction : A> on(
+    @PublishedApi
+    internal fun <SubAction : A> on(
         actionClass: KClass<SubAction>,
         executionPolicy: ExecutionPolicy,
         handler: suspend (action: SubAction, state: State<InputState>) -> ChangedState<S>,
@@ -93,7 +94,8 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
      *  triggering analytics.
      *  This is the "effect counterpart" to handling actions that you would do with [on].
      */
-    public fun <SubAction : A> onActionEffect(
+    @PublishedApi
+    internal fun <SubAction : A> onActionEffect(
         actionClass: KClass<SubAction>,
         executionPolicy: ExecutionPolicy,
         handler: suspend (action: SubAction, stateSnapshot: InputState) -> Unit,
@@ -334,7 +336,8 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
         )
     }
 
-    public fun <SubAction : A, SubStateMachineState : Any, SubStateMachineAction : Any> onActionStartStateMachine(
+    @PublishedApi
+    internal fun <SubAction : A, SubStateMachineState : Any, SubStateMachineAction : Any> onActionStartStateMachine(
         actionClass: KClass<out SubAction>,
         stateMachineFactory: (SubAction, InputState) -> FlowReduxStateMachine<SubStateMachineState, SubStateMachineAction>,
         actionMapper: (A) -> SubStateMachineAction?,

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/StartStateMachineOnActionInStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/StartStateMachineOnActionInStateSideEffectBuilder.kt
@@ -6,7 +6,6 @@ import com.freeletics.flowredux.SideEffect
 import com.freeletics.flowredux.GetState
 import com.freeletics.flowredux.dsl.ChangedState
 import com.freeletics.flowredux.dsl.FlowReduxDsl
-import com.freeletics.flowredux.dsl.FlowReduxStateMachine
 import com.freeletics.flowredux.dsl.State
 import com.freeletics.flowredux.dsl.flow.whileInState
 import com.freeletics.mad.statemachine.StateMachine
@@ -24,7 +23,7 @@ import kotlinx.coroutines.sync.withLock
 @FlowPreview
 @ExperimentalCoroutinesApi
 internal class StartStateMachineOnActionInStateSideEffectBuilder<SubStateMachineState : Any, SubStateMachineAction : Any, InputState : S, ActionThatTriggeredStartingStateMachine : A, S : Any, A : Any>(
-    private val subStateMachineFactory: (action: ActionThatTriggeredStartingStateMachine, state: InputState) -> FlowReduxStateMachine<SubStateMachineState, SubStateMachineAction>,
+    private val subStateMachineFactory: (action: ActionThatTriggeredStartingStateMachine, state: InputState) -> StateMachine<SubStateMachineState, SubStateMachineAction>,
     private val actionMapper: (A) -> SubStateMachineAction?,
     private val stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S>,
     private val isInState: (S) -> Boolean,

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/StartStateMachineOnActionInStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/StartStateMachineOnActionInStateSideEffectBuilder.kt
@@ -22,8 +22,7 @@ import kotlinx.coroutines.sync.withLock
 
 @FlowPreview
 @ExperimentalCoroutinesApi
-internal class StartStateMachineOnActionInStateSideEffectBuilder<SubStateMachineState : Any, SubStateMachineAction : Any, InputState : S, ActionThatTriggeredStartingStateMachine : A, S : Any, A : Any>
-(
+internal class StartStateMachineOnActionInStateSideEffectBuilder<SubStateMachineState : Any, SubStateMachineAction : Any, InputState : S, ActionThatTriggeredStartingStateMachine : A, S : Any, A : Any>(
     private val subStateMachineFactory: (action: ActionThatTriggeredStartingStateMachine, state: InputState) -> FlowReduxStateMachine<SubStateMachineState, SubStateMachineAction>,
     private val actionMapper: (A) -> SubStateMachineAction?,
     private val stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S>,

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
With this these methods that only exist to be called from the reified inline methods are hidden from auto completion since they are internal but still accessible to the inline functions. This is a binary compatible change (see `flowredux.api` file, the change there comes from removing the `@JvmSynthetic`)