### PR TITLE
allow any StateMachine to be a sub state machine

### DIFF
--- a/flowredux/api/flowredux.api
+++ b/flowredux/api/flowredux.api
@@ -46,12 +46,12 @@ public final class com/freeletics/flowredux/dsl/InStateBuilderBlock {
 	public final fun onActionStartStateMachine (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
 	public final fun onEnter (Lkotlin/jvm/functions/Function2;)V
 	public final fun onEnterEffect (Lkotlin/jvm/functions/Function2;)V
-	public final fun onEnterStartStateMachine (Lcom/freeletics/flowredux/dsl/FlowReduxStateMachine;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
-	public final fun onEnterStartStateMachine (Lcom/freeletics/flowredux/dsl/FlowReduxStateMachine;Lkotlin/jvm/functions/Function2;)V
+	public final fun onEnterStartStateMachine (Lcom/freeletics/mad/statemachine/StateMachine;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
+	public final fun onEnterStartStateMachine (Lcom/freeletics/mad/statemachine/StateMachine;Lkotlin/jvm/functions/Function2;)V
 	public final fun onEnterStartStateMachine (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
 	public final fun onEnterStartStateMachine (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
-	public static synthetic fun onEnterStartStateMachine$default (Lcom/freeletics/flowredux/dsl/InStateBuilderBlock;Lcom/freeletics/flowredux/dsl/FlowReduxStateMachine;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public static synthetic fun onEnterStartStateMachine$default (Lcom/freeletics/flowredux/dsl/InStateBuilderBlock;Lcom/freeletics/flowredux/dsl/FlowReduxStateMachine;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun onEnterStartStateMachine$default (Lcom/freeletics/flowredux/dsl/InStateBuilderBlock;Lcom/freeletics/mad/statemachine/StateMachine;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun onEnterStartStateMachine$default (Lcom/freeletics/flowredux/dsl/InStateBuilderBlock;Lcom/freeletics/mad/statemachine/StateMachine;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public static synthetic fun onEnterStartStateMachine$default (Lcom/freeletics/flowredux/dsl/InStateBuilderBlock;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public static synthetic fun onEnterStartStateMachine$default (Lcom/freeletics/flowredux/dsl/InStateBuilderBlock;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
@@ -9,6 +9,7 @@ import com.freeletics.flowredux.dsl.internal.OnActionInStateSideEffectBuilder
 import com.freeletics.flowredux.dsl.internal.OnEnterInStateSideEffectBuilder
 import com.freeletics.flowredux.dsl.internal.StartStateMachineOnActionInStateSideEffectBuilder
 import com.freeletics.flowredux.dsl.internal.StartStatemachineOnEnterSideEffectBuilder
+import com.freeletics.mad.statemachine.StateMachine
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -239,7 +240,7 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
     }
 
     public fun <SubStateMachineState : Any> onEnterStartStateMachine(
-        stateMachine: FlowReduxStateMachine<SubStateMachineState, A>,
+        stateMachine: StateMachine<SubStateMachineState, A>,
         stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S> = { _, subState ->
             @Suppress("UNCHECKED_CAST")
             OverrideState(subState as S)
@@ -253,7 +254,7 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
     }
 
     public fun <SubStateMachineState : Any> onEnterStartStateMachine(
-        stateMachineFactory: (InputState) -> FlowReduxStateMachine<SubStateMachineState, A>,
+        stateMachineFactory: (InputState) -> StateMachine<SubStateMachineState, A>,
         stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S> = { _, subState ->
             @Suppress("UNCHECKED_CAST")
             OverrideState(subState as S)
@@ -267,7 +268,7 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
     }
 
     public fun <SubStateMachineState : Any, SubStateMachineAction : Any> onEnterStartStateMachine(
-        stateMachine: FlowReduxStateMachine<SubStateMachineState, SubStateMachineAction>,
+        stateMachine: StateMachine<SubStateMachineState, SubStateMachineAction>,
         actionMapper: (A) -> SubStateMachineAction?,
         stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S> = { _, subState ->
             @Suppress("UNCHECKED_CAST")
@@ -282,7 +283,7 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
     }
 
     public fun <SubStateMachineState : Any, SubStateMachineAction : Any> onEnterStartStateMachine(
-        stateMachineFactory: (InputState) -> FlowReduxStateMachine<SubStateMachineState, SubStateMachineAction>,
+        stateMachineFactory: (InputState) -> StateMachine<SubStateMachineState, SubStateMachineAction>,
         actionMapper: (A) -> SubStateMachineAction?,
         stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S> = { _, subState ->
             @Suppress("UNCHECKED_CAST")
@@ -300,7 +301,7 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
     }
 
     public inline fun <reified SubAction : A, SubStateMachineState : Any> onActionStartStateMachine(
-        stateMachine: FlowReduxStateMachine<SubStateMachineState, A>,
+        stateMachine: StateMachine<SubStateMachineState, A>,
         noinline stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S>,
     ) {
         onActionStartStateMachine(
@@ -311,7 +312,7 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
     }
 
     public inline fun <reified SubAction : A, SubStateMachineState : Any> onActionStartStateMachine(
-        noinline stateMachineFactory: (SubAction, InputState) -> FlowReduxStateMachine<SubStateMachineState, A>,
+        noinline stateMachineFactory: (SubAction, InputState) -> StateMachine<SubStateMachineState, A>,
         noinline stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S>,
     ) {
         onActionStartStateMachine(
@@ -322,7 +323,7 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
     }
 
     public inline fun <reified SubAction : A, SubStateMachineState : Any, SubStateMachineAction : Any> onActionStartStateMachine(
-        noinline stateMachineFactory: (SubAction, InputState) -> FlowReduxStateMachine<SubStateMachineState, SubStateMachineAction>,
+        noinline stateMachineFactory: (SubAction, InputState) -> StateMachine<SubStateMachineState, SubStateMachineAction>,
         noinline actionMapper: (A) -> SubStateMachineAction?,
         noinline stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S>,
     ) {
@@ -336,7 +337,7 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any>(
 
     public fun <SubAction : A, SubStateMachineState : Any, SubStateMachineAction : Any> onActionStartStateMachine(
         actionClass: KClass<out SubAction>,
-        stateMachineFactory: (SubAction, InputState) -> FlowReduxStateMachine<SubStateMachineState, SubStateMachineAction>,
+        stateMachineFactory: (SubAction, InputState) -> StateMachine<SubStateMachineState, SubStateMachineAction>,
         actionMapper: (A) -> SubStateMachineAction?,
         stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S>,
     ) {

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/StartStateMachineOnActionInStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/StartStateMachineOnActionInStateSideEffectBuilder.kt
@@ -9,6 +9,7 @@ import com.freeletics.flowredux.dsl.FlowReduxDsl
 import com.freeletics.flowredux.dsl.FlowReduxStateMachine
 import com.freeletics.flowredux.dsl.State
 import com.freeletics.flowredux.dsl.flow.whileInState
+import com.freeletics.mad.statemachine.StateMachine
 import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -24,7 +25,7 @@ import kotlinx.coroutines.sync.withLock
 @ExperimentalCoroutinesApi
 internal class StartStateMachineOnActionInStateSideEffectBuilder<SubStateMachineState : Any, SubStateMachineAction : Any, InputState : S, ActionThatTriggeredStartingStateMachine : A, S : Any, A : Any>
 (
-    private val subStateMachineFactory: (action: ActionThatTriggeredStartingStateMachine, state: InputState) -> FlowReduxStateMachine<SubStateMachineState, SubStateMachineAction>,
+    private val subStateMachineFactory: (action: ActionThatTriggeredStartingStateMachine, state: InputState) -> StateMachine<SubStateMachineState, SubStateMachineAction>,
     private val actionMapper: (A) -> SubStateMachineAction?,
     private val stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S>,
     private val isInState: (S) -> Boolean,
@@ -105,7 +106,7 @@ internal class StartStateMachineOnActionInStateSideEffectBuilder<SubStateMachine
         @ExperimentalCoroutinesApi
         @FlowPreview
         internal data class StateMachineAndJob<S : Any, A : Any>(
-            val stateMachine: FlowReduxStateMachine<S, A>,
+            val stateMachine: StateMachine<S, A>,
             val job: Job,
         )
 
@@ -114,7 +115,7 @@ internal class StartStateMachineOnActionInStateSideEffectBuilder<SubStateMachine
 
         suspend fun size(): Int = mutex.withLock { stateMachinesAndJobsMap.size }
 
-        suspend fun cancelPreviousAndAddNew(actionThatStartedStateMachine: ActionThatTriggeredStartingStateMachine, stateMachine: FlowReduxStateMachine<S, A>, job: Job) {
+        suspend fun cancelPreviousAndAddNew(actionThatStartedStateMachine: ActionThatTriggeredStartingStateMachine, stateMachine: StateMachine<S, A>, job: Job) {
             mutex.withLock {
                 val existingStateMachinesAndJobs: StateMachineAndJob<S, A>? = stateMachinesAndJobsMap[actionThatStartedStateMachine]
                 existingStateMachinesAndJobs?.job?.cancel()
@@ -123,7 +124,7 @@ internal class StartStateMachineOnActionInStateSideEffectBuilder<SubStateMachine
             }
         }
 
-        suspend inline fun forEachStateMachine(crossinline block: suspend (FlowReduxStateMachine<S, A>) -> Unit) {
+        suspend inline fun forEachStateMachine(crossinline block: suspend (StateMachine<S, A>) -> Unit) {
             mutex.withLock {
                 stateMachinesAndJobsMap.values.forEach { stateMachineAndJob ->
                     block(stateMachineAndJob.stateMachine)
@@ -131,7 +132,7 @@ internal class StartStateMachineOnActionInStateSideEffectBuilder<SubStateMachine
             }
         }
 
-        suspend fun remove(stateMachine: FlowReduxStateMachine<S, A>): StateMachineAndJob<S, A>? {
+        suspend fun remove(stateMachine: StateMachine<S, A>): StateMachineAndJob<S, A>? {
             // could be optimized for better runtime
             val result = mutex.withLock {
                 var key: ActionThatTriggeredStartingStateMachine? = null

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/StartStatemachineOnEnterSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/StartStatemachineOnEnterSideEffectBuilder.kt
@@ -8,6 +8,7 @@ import com.freeletics.flowredux.dsl.FlowReduxStateMachine
 import com.freeletics.flowredux.dsl.State
 import com.freeletics.flowredux.dsl.flow.mapToIsInState
 import com.freeletics.flowredux.dsl.flow.whileInState
+import com.freeletics.mad.statemachine.StateMachine
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.coroutineScope
@@ -17,7 +18,7 @@ import kotlinx.coroutines.launch
 @ExperimentalCoroutinesApi
 @FlowPreview
 internal class StartStatemachineOnEnterSideEffectBuilder<SubStateMachineState : Any, SubStateMachineAction : Any, InputState : S, S : Any, A>(
-    private val subStateMachineFactory: (InputState) -> FlowReduxStateMachine<SubStateMachineState, SubStateMachineAction>,
+    private val subStateMachineFactory: (InputState) -> StateMachine<SubStateMachineState, SubStateMachineAction>,
     private val actionMapper: (A) -> SubStateMachineAction?,
     private val stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S>,
     private val isInState: (S) -> Boolean
@@ -42,7 +43,7 @@ internal class StartStatemachineOnEnterSideEffectBuilder<SubStateMachineState : 
                 } else {
                     // create sub statemachine via factory.
                     // Cleanup of instantiated sub statemachine reference is happening in .onComplete {...}
-                    var subStateMachine: FlowReduxStateMachine<SubStateMachineState, SubStateMachineAction>? =
+                    var subStateMachine: StateMachine<SubStateMachineState, SubStateMachineAction>? =
                         subStateMachineFactory(stateOnEntering)
 
                     // build the to be returned flow

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
My idea is to migrate some bigger older state machines in our code base to flow redux gradually by making them a sub state machine of the flow redux replacement. To make that possible all sub state machine dsl methods now get `StateMachine` instead of `FlowReduxStateMachine`. Since it is a super interface the change should be binary compatible.