### PR TITLE
deploy website directly from github actions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,11 +10,20 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install JDK 11
+      - name: Install JDK
         uses: actions/setup-java@v3
         with:
           distribution: zulu
@@ -42,10 +51,14 @@ jobs:
           mkdir -p docs/API/compose
           cp -R compose/build/dokka/html/. docs/API/compose
 
+      - name: Build MkDocs
+        run: mkdocs build
 
-      - name: Deploy MkDocs
-        run: |
-          git fetch origin gh-pages:gh-pages
-          mkdocs gh-deploy --force
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This makes the gh pages branch obsolete. Instead of building the site and pushing it to that branch the action uploads it and triggers a deployment. We've been using it in mad for a while now https://github.com/freeletics/mad/blob/main/.github/workflows/publish-docs.yml