### PR TITLE
rename all tests

### DIFF
--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/FlowReduxTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/FlowReduxTest.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.test.runTest
 class FlowReduxTest {
 
     @Test
-    fun `initial state is emitted even without actions as input`() = runTest {
+    fun initialStateIsEmittedEvenWithoutActionsAsInput() = runTest {
         var reducerInvocations = 0
 
         emptyFlow<Int>()
@@ -37,7 +37,7 @@ class FlowReduxTest {
     }
 
     @Test
-    fun `store without side effects just runs reducer`() = runTest {
+    fun storeWithoutSideEffectsJustRunsReducer() = runTest {
         flow {
             emit(1)
             emit(2)
@@ -52,7 +52,7 @@ class FlowReduxTest {
     }
 
     @Test
-    fun `store with empty side effect that emits nothing`() = runTest {
+    fun storeWithEmptySideEffectThatEmitsNothing() = runTest {
         val sideEffect1Actions = mutableListOf<Int>()
 
         val sideEffect1: SideEffect<String, Int> = { actions, _ ->
@@ -77,7 +77,7 @@ class FlowReduxTest {
     }
 
     @Test
-    fun `store with 2 side effects and they emit nothing`() = runTest {
+    fun storeWith2SideEffectsAndTheyEmitNothing() = runTest {
         val sideEffect1Actions = mutableListOf<Int>()
         val sideEffect2Actions = mutableListOf<Int>()
 
@@ -104,7 +104,7 @@ class FlowReduxTest {
     }
 
     @Test
-    fun `store with 2 simple side effects`() = runTest {
+    fun storeWith2SimpleSideEffects() = runTest {
         val sideEffect1: SideEffect<String, Int> = { actions, _ ->
             actions.flatMapConcat {
                 if (it < 6) {
@@ -147,7 +147,7 @@ class FlowReduxTest {
     }
 
     @Test
-    fun `store with 2 simple side effects synchronous`() = runTest {
+    fun storeWith2SimpleSideEffectsSynchronous() = runTest {
         val sideEffect1: SideEffect<String, Int> = { actions, _ ->
             actions.flatMapConcat {
                 if (it < 6) {
@@ -190,7 +190,7 @@ class FlowReduxTest {
     }
 
     @Test
-    fun `canceling the flow of input actions also cancels all side effects`() = runTest {
+    fun cancelingTheFlowOfInputActionsAlsoCancelsAllSideEffects() = runTest {
         var sideEffect1Started = false
         var sideEffect2Started = false
         var sideEffect1Ended = false

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateEffectTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateEffectTest.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.test.runTest
 class CollectWhileInStateEffectTest {
 
     @Test
-    fun `collectWhileInStateEffect stops after having moved to next state`() = runTest {
+    fun collectWhileInStateEffectStopsAfterHavingMovedToNextState() = runTest {
         val stateChange = MutableSharedFlow<Unit>()
         val values = MutableSharedFlow<Int>()
         val recordedValues = Channel<Int>(Channel.UNLIMITED)
@@ -46,7 +46,7 @@ class CollectWhileInStateEffectTest {
     }
 
     @Test
-    fun `collectWhileInStateEffect with flowBuilder stops after having moved to next state`() = runTest {
+    fun collectWhileInStateEffectWithFlowBuilderStopsAfterHavingMovedToNextState() = runTest {
         val stateChange = MutableSharedFlow<Unit>()
         val values = MutableSharedFlow<Int>()
         val recordedValues = Channel<Int>(Channel.UNLIMITED)

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CollectWhileInStateTest.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.test.runTest
 class CollectWhileInStateTest {
 
     @Test
-    fun `collectWhileInState stops after having moved to next state`() = runTest {
+    fun collectWhileInStateStopsAfterHavingMovedToNextState() = runTest {
         val values = MutableSharedFlow<Int>()
         val recordedValues = Channel<Int>(Channel.UNLIMITED)
 
@@ -43,7 +43,7 @@ class CollectWhileInStateTest {
     }
 
     @Test
-    fun `collectWhileInState with flowBuilder stops after having moved to next state`() = runTest {
+    fun collectWhileInStateWithFlowBuilderStopsAfterHavingMovedToNextState() = runTest {
         val values = MutableSharedFlow<Int>()
         val recordedValues = Channel<Int>(Channel.UNLIMITED)
 
@@ -70,7 +70,7 @@ class CollectWhileInStateTest {
     }
 
     @Test
-    fun `move from collectWhileInState to next state with action`() = runTest {
+    fun moveFromCollectWhileInStateToNextStateWithAction() = runTest {
         val sm = StateMachine {
             inState<TestState.Initial> {
                 collectWhileInState(flowOf(1)) { _, state ->
@@ -110,7 +110,7 @@ class CollectWhileInStateTest {
     }
 
     @Test
-    fun `collectWhileInState flowBuilder receives any GenericState state update`() = runTest {
+    fun collectWhileInStateFlowBuilderReceivesAnyGenericStateStateUpdate() = runTest {
         val sm = StateMachine {
             inState<TestState.Initial> {
                 onEnter {

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CustomIsInStateDslTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/CustomIsInStateDslTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.runTest
 class CustomIsInStateDslTest {
 
     @Test
-    fun `on Action triggers only while in custom state`() = runTest {
+    fun onActionTriggersOnlyWhileInCustomState() = runTest {
         var counter1 = 0
         var counter2 = 0
 
@@ -62,7 +62,7 @@ class CustomIsInStateDslTest {
     }
 
     @Test
-    fun `collectWhileInState stops when leaving custom state`() = runTest {
+    fun collectWhileInStateStopsWhenLeavingCustomState() = runTest {
         var reached = false
 
         val gs1 = TestState.GenericState("asd", 1)

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachineTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachineTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.runTest
 class FlowReduxStateMachineTest {
 
     @Test
-    fun `empty state machine just emits initial state`() = runTest {
+    fun emptyStateMachineJustEmitsInitialState() = runTest {
         val sm = StateMachine { }
         sm.state.test {
             assertEquals(TestState.Initial, awaitItem())
@@ -23,7 +23,7 @@ class FlowReduxStateMachineTest {
     }
 
     @Test
-    fun `calling spec block twice throws exception`() {
+    fun callingSpecBlockTwiceThrowsException() {
         val sm = object : FlowReduxStateMachine<Any, Any>(Any()) {
 
             init {
@@ -46,7 +46,7 @@ class FlowReduxStateMachineTest {
     }
 
     @Test
-    fun `no spec block set throws exception`() {
+    fun noSpecBlockSetThrowsException() {
         val sm = object : FlowReduxStateMachine<Any, Any>(Any()) {}
 
         try {
@@ -73,7 +73,7 @@ class FlowReduxStateMachineTest {
     }
 
     @Test
-    fun `dispatching without any state flow collector throws exception`() = runTest {
+    fun dispatchingWithoutAnyStateFlowCollectorThrowsException() = runTest {
         val sm = StateMachine {}
 
         val action = TestAction.A1
@@ -90,7 +90,7 @@ class FlowReduxStateMachineTest {
     }
 
     @Test
-    fun `observing state multiple times in parallel throws exception`() = runTest {
+    fun observingStateMultipleTimesInParallelThrowsException() = runTest {
         val sm = StateMachine {}
 
         var collectionStarted = false
@@ -119,7 +119,7 @@ class FlowReduxStateMachineTest {
     }
 
     @Test
-    fun `observing state multiple times in sequence`() = runTest {
+    fun observingStateMultipleTimesInSequence() = runTest {
         val sm = StateMachine {}
 
         // each call will collect the first item and then stop collecting

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionEffectTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionEffectTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.runTest
 class OnActionEffectTest {
 
     @Test
-    fun `action effect block stops when moved to another state`() = runTest {
+    fun actionEffectBlockStopsWhenMovedToAnotherState() = runTest {
         val signal = Channel<Unit>()
         val blockEntered = Channel<Boolean>(Channel.UNLIMITED)
 
@@ -49,7 +49,7 @@ class OnActionEffectTest {
     }
 
     @Test
-    fun `on action effect is triggered`() = runTest {
+    fun onActionEffectIsTriggered() = runTest {
         val signal = Channel<Unit>()
         val triggered = Channel<Boolean>(Channel.UNLIMITED)
 

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.runTest
 class OnActionTest {
 
     @Test
-    fun `action block stops when moved to another state`() = runTest {
+    fun actionBlockStopsWhenMovedToAnotherState() = runTest {
         val signal = Channel<Unit>()
         val blockEntered = Channel<Boolean>()
 
@@ -50,7 +50,7 @@ class OnActionTest {
     }
 
     @Test
-    fun `on action gets triggered and moves to next state`() = runTest {
+    fun onActionGetsTriggeredAndMovesToNextState() = runTest {
         val sm = StateMachine {
             inState<TestState.Initial> {
                 on<TestAction.A1> { _, state ->

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterEffectTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterEffectTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.runTest
 class OnEnterEffectTest {
 
     @Test
-    fun `onEnter effect block stops when moved to another state`() = runTest {
+    fun onEnterEffectBlockStopsWhenMovedToAnotherState() = runTest {
         val signal = Channel<Unit>()
         val blockEntered = Channel<Boolean>(Channel.UNLIMITED)
 
@@ -48,7 +48,7 @@ class OnEnterEffectTest {
     }
 
     @Test
-    fun `on entering the same state does not trigger onEnterEffect again`() = runTest {
+    fun onEnteringTheSameStateDoesNotTriggerOnEnterEffectAgain() = runTest {
         var genericStateEffectEntered = 0
         var a1Received = 0
 

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnEnterTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.runTest
 class OnEnterTest {
 
     @Test
-    fun `onEnter block stops when moved to another state`() = runTest {
+    fun onEnterBlockStopsWhenMovedToAnotherState() = runTest {
         val signal = Channel<Unit>()
         val blockEntered = Channel<Boolean>(Channel.UNLIMITED)
 
@@ -49,7 +49,7 @@ class OnEnterTest {
     }
 
     @Test
-    fun `on entering the same state does not trigger onEnter again`() = runTest {
+    fun onEnteringTheSameStateDoesNotTriggerOnEnterAgain() = runTest {
         var genericStateEntered = 0
         var a1Received = 0
 

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/ReducerTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/ReducerTest.kt
@@ -13,7 +13,7 @@ class ReducerTest {
     }
 
     @Test
-    fun `run SelfReducibleAction on returning True`() {
+    fun runSelfReducibleActionOnReturningTrue() {
         val action =
             ChangeStateAction<TestState, Any>(
                 changedState = UnsafeMutateState<TestState, TestState> { TestState.B },
@@ -30,7 +30,7 @@ class ReducerTest {
     }
 
     @Test
-    fun `do not run SelfReducibleAction on returning False`() {
+    fun doNotRunSelfReducibleActionOnReturningFalse() {
         val action =
             ChangeStateAction<TestState, Any>(
                 changedState = UnsafeMutateState<TestState, TestState> { TestState.B },

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/StartStateMachineOnActionInStateTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/StartStateMachineOnActionInStateTest.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.test.runTest
 class StartStateMachineOnActionInStateTest {
 
     @Test
-    fun `child state machine emits initial state to parent state machine`() = runTest {
+    fun childStateMachineEmitsInitialStateToParentStateMachine() = runTest {
         var childStateChanged = 0
         val child = StateMachine(initialState = TestState.S3)
         val parentStateMachine = StateMachine {
@@ -36,7 +36,7 @@ class StartStateMachineOnActionInStateTest {
     }
 
     @Test
-    fun `child state machine stops after leaving While In State`() = runTest {
+    fun childStateMachineStopsAfterLeavingWhileInState() = runTest {
         var childStateChanged = 0
         val child = StateMachine(initialState = TestState.S3)
         val parentStateMachine = StateMachine {
@@ -62,7 +62,7 @@ class StartStateMachineOnActionInStateTest {
     }
 
     @Test
-    fun `actions are forwarded to the sub state machine and sub state is propagated back ONLY while in state`() = runTest {
+    fun actionsAreForwardedToTheSubStateMachineAndSubStateIsPropagatedBackONLYWhileInState() = runTest {
         var childStateChanged = 0
         var childS3A2Handled = 0
         var childS1A2Handled = 0
@@ -132,7 +132,7 @@ class StartStateMachineOnActionInStateTest {
     }
 
     @Test
-    fun `sub state machine factory is invoked on re-enter and action and state mapper are invoked`() = runTest {
+    fun subStateMachineFactoryIsInvokedOnReEnterAndActionAndStateMapperAreInvoked() = runTest {
         val actionMapperRecordings = mutableListOf<TestAction>()
         val factoryParamsRecordings = mutableListOf<Pair<TestAction, TestState>>()
         val stateMapperRecordings = mutableListOf<Pair<TestState, TestState>>()
@@ -314,7 +314,7 @@ class StartStateMachineOnActionInStateTest {
     }
 
     @Test
-    fun `actions are only dispatched to sub statemachine if they are not mapped to null`() = runTest {
+    fun actionsAreOnlyDispatchedToSubStatemachineIfTheyAreNotMappedToNull() = runTest {
         val childActionInvocations = Channel<Unit>(Channel.UNLIMITED)
         val parentActionInvocations = Channel<Unit>(Channel.UNLIMITED)
 

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/SubStateMachineTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/SubStateMachineTest.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.test.runTest
 class SubStateMachineTest {
 
     @Test
-    fun `child state machine emits initial state to parent state machine`() = runTest {
+    fun childStateMachineEmitsInitialStateToParentStateMachine() = runTest {
         val child = ChildStateMachine(initialState = TestState.S3) { }
         val stateMachine = StateMachine {
             inState<TestState.Initial> {
@@ -29,7 +29,7 @@ class SubStateMachineTest {
     }
 
     @Test
-    fun `delegate to child sub state machine while in state`() = runTest {
+    fun delegateToChildSubStateMachineWhileInState() = runTest {
         var inS3onA1Action = 0
         var inS2OnA1Action = 0
         val receivedChildStateUpdates = mutableListOf<TestState>()
@@ -94,7 +94,7 @@ class SubStateMachineTest {
     }
 
     @Test
-    fun `sub state machine does not restart if state parent state is still the same`() = runTest {
+    fun subStateMachineDoesNotRestartIfStateParentStateIsStillTheSame() = runTest {
         val factoryInvocations = Channel<Unit>(Channel.UNLIMITED)
         val childEntersInitialState = Channel<Unit>(Channel.UNLIMITED)
 
@@ -141,7 +141,7 @@ class SubStateMachineTest {
     }
 
     @Test
-    fun `sub state machine factory is called every time parent state is entered`() = runTest {
+    fun subStateMachineFactoryIsCalledEveryTimeParentStateIsEntered() = runTest {
         val factoryInvocations = Channel<Unit>(Channel.UNLIMITED)
         val childEntersInitialState = Channel<Unit>(Channel.UNLIMITED)
 
@@ -202,7 +202,7 @@ class SubStateMachineTest {
     }
 
     @Test
-    fun `actions are only dispatched to sub state machine while parent state machine is in state`() = runTest {
+    fun actionsAreOnlyDispatchedToSubStateMachineWhileParentStateMachineIsInState() = runTest {
         val childActionInvocations = Channel<Unit>(Channel.UNLIMITED)
         val parentActionInvocations = Channel<Unit>(Channel.UNLIMITED)
         val child = ChildStateMachine(initialState = TestState.S1) {
@@ -250,7 +250,7 @@ class SubStateMachineTest {
     }
 
     @Test
-    fun `actions are only dispatched to sub state machine if they are mapped`() = runTest {
+    fun actionsAreOnlyDispatchedToSubStateMachineIfTheyAreMapped() = runTest {
         val childActionInvocations = Channel<Unit>(Channel.UNLIMITED)
         val parentActionInvocations = Channel<Unit>(Channel.UNLIMITED)
         val child = ChildStateMachine(initialState = TestState.S1) {
@@ -311,7 +311,7 @@ class SubStateMachineTest {
     }
 
     @Test
-    fun `reentering state so that sub state machine triggers works with same child instate`() = runTest {
+    fun reenteringStateSoThatSubStateMachineTriggersWorksWithSameChildInstate() = runTest {
         var childOnEnterS2 = 0
         var childActionA2 = 0
         var parentS2 = 0

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/internal/SubStateMachinesMapTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/internal/SubStateMachinesMapTest.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.withTimeout
 class SubStateMachinesMapTest {
 
     @Test
-    fun `adding new state machine works and cancels previous one`() = runTest {
+    fun addingNewStateMachineWorksAndCancelsPreviousOne() = runTest {
         val map = StartStateMachineOnActionInStateSideEffectBuilder.SubStateMachinesMap<TestState, TestAction, TestAction.A4>()
 
         val actionThatTriggered = TestAction.A4(1)
@@ -51,7 +51,7 @@ class SubStateMachinesMapTest {
     }
 
     @Test
-    fun `adding state machine does not cancel previous if ActionThatTriggered is not equal to original one`() = runTest {
+    fun addingStateMachineDoesNotCancelPreviousIfActionThatTriggeredIsNotEqualToOriginalOne() = runTest {
         val map = StartStateMachineOnActionInStateSideEffectBuilder.SubStateMachinesMap<TestState, TestAction, TestAction.A4>()
 
         val a1 = TestAction.A4(1)
@@ -97,7 +97,7 @@ class SubStateMachinesMapTest {
     }
 
     @Test
-    fun `iterating over all state machines work`() = runTest {
+    fun iteratingOverAllStateMachinesWork() = runTest {
         val map = StartStateMachineOnActionInStateSideEffectBuilder.SubStateMachinesMap<TestState, TestAction, TestAction.A4>()
         val a1 = TestAction.A4(1)
         val s1 = StateMachine()


### PR DESCRIPTION
In preparation for adding Kotlin/JS as a target all tests need to be renamed because spaces in method names are not supported for Kotlin/JS. They are not as nice as before but there is not much we can do.