### PR TITLE
fix flaky tests

### DIFF
--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionEffectTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionEffectTest.kt
@@ -9,6 +9,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -25,6 +28,8 @@ class OnActionEffectTest {
                 onActionEffect<TestAction.A1> { _, _ ->
                     blockEntered.send(true)
                     signal.awaitComplete()
+                    // while we wait for S2 to be emitted which cancels the block the cancelattion might happen slightly afterwards
+                    delay(100)
                     // this should never be reached because state transition did happen in the meantime,
                     // therefore this whole block must be canceled
                     reached = true
@@ -43,6 +48,8 @@ class OnActionEffectTest {
             sm.dispatchAsync(TestAction.A2)
             assertEquals(TestState.S2, awaitItem())
             signal.close()
+            advanceUntilIdle()
+            runCurrent()
         }
 
         assertFalse(reached)


### PR DESCRIPTION
These were flaky because the state emission might happen before the new state is fully propagated internally, so while we receive `assertEquals(TestState.S2, awaitItem())` the cancellation of the old state might not have happened yet. The `signal.close()` might then also happen before that which causes `reached` to become `true`. The delay isn't nice but it causes the internal coroutines before which then causes the block to be cancelled during the delay. (note that this is not a real time delay, just virtual time in the test scheduler, so the time value there doesn't matter). I've tested both of them by running them 1k times each.