### PR TITLE
onActionStartStateMachine():  Make sure SubStateMachine State Flow is collected before dispatching actions to it

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CoroutineWaiter.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CoroutineWaiter.kt
@@ -29,7 +29,7 @@ internal value class CoroutineWaiter(private val job: CompletableJob = Job()) {
      * Suspends the current coroutine (that calls this method) until #resume()
      * is called (by another coroutine).
      */
-    suspend inline fun waitUntilResumed() {
+    internal suspend inline fun waitUntilResumed() {
         job.join()
     }
 
@@ -38,11 +38,22 @@ internal value class CoroutineWaiter(private val job: CompletableJob = Job()) {
      *
      * Calling this method multiple times has no effect. Once resumed, it stays resumed forever.
      */
-    fun resume() {
+    internal fun resume() {
         job.complete()
     }
 
-    fun isResumed(): Boolean {
+    internal fun isResumed(): Boolean {
         return job.isCompleted
     }
+
+    /**
+     * This function is only meant to be used for unit testing purposes.
+     *
+     * Returns true if this [CoroutineWaiter] is the same as the [other] [CoroutineWaiter]
+     * by comparing the identity of the underlying [Job] instance.
+     *
+     * The reason why this function exists is because inline value classes do not support identity comparison
+     * with === operator nor equals() comparison. It is simply not implemented and supported by the kotlin compiler.
+     */
+    internal fun isTheSame(other: CoroutineWaiter): Boolean = job === other.job
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CoroutineWaiter.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CoroutineWaiter.kt
@@ -45,15 +45,4 @@ internal value class CoroutineWaiter(private val job: CompletableJob = Job()) {
     internal fun isResumed(): Boolean {
         return job.isCompleted
     }
-
-    /**
-     * This function is only meant to be used for unit testing purposes.
-     *
-     * Returns true if this [CoroutineWaiter] is the same as the [other] [CoroutineWaiter]
-     * by comparing the identity of the underlying [Job] instance.
-     *
-     * The reason why this function exists is because inline value classes do not support identity comparison
-     * with === operator nor equals() comparison. It is simply not implemented and supported by the kotlin compiler.
-     */
-    internal fun isTheSame(other: CoroutineWaiter): Boolean = job === other.job
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CoroutineWaiter.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/internal/CoroutineWaiter.kt
@@ -45,4 +45,15 @@ internal value class CoroutineWaiter(private val job: CompletableJob = Job()) {
     internal fun isResumed(): Boolean {
         return job.isCompleted
     }
+
+    /**
+     * This function is only meant to be used for unit testing purposes.
+     *
+     * Returns true if this [CoroutineWaiter] is the same as the [other] [CoroutineWaiter]
+     * by comparing the identity of the underlying [Job] instance.
+     *
+     * The reason why this function exists is because inline value classes do not support identity comparison
+     * with === operator nor equals() comparison. It is simply not implemented and supported by the kotlin compiler.
+     */
+    internal fun isTheSame(other: CoroutineWaiter): Boolean = job === other.job
 }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/internal/SubStateMachinesMapTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/internal/SubStateMachinesMapTest.kt
@@ -132,12 +132,12 @@ internal class SubStateMachinesMapTest {
             when (i) {
                 0 -> {
                     assertSame(s1, sm)
-                    assertTrue(w1.isTheSame(waiter))
+                    assertEquals(w2, waiter)
                 }
 
                 1 -> {
                     assertSame(s2, sm)
-                    assertTrue(w2.isTheSame(waiter))
+                    assertEquals(w2, waiter)
                 }
                 else -> throw Exception("Unexpected loop value $i")
             }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/internal/SubStateMachinesMapTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/internal/SubStateMachinesMapTest.kt
@@ -132,12 +132,12 @@ internal class SubStateMachinesMapTest {
             when (i) {
                 0 -> {
                     assertSame(s1, sm)
-                    assertEquals(w2, waiter)
+                    assertTrue(w1.isTheSame(waiter))
                 }
 
                 1 -> {
                     assertSame(s2, sm)
-                    assertEquals(w2, waiter)
+                    assertTrue(w2.isTheSame(waiter))
                 }
                 else -> throw Exception("Unexpected loop value $i")
             }


### PR DESCRIPTION
Follow up on #482 , this time for the `onActionStartStateMachine()` DSL block.

Uses `CoroutineWaiter()` to synchronize coroutines for collecting state and dispatching actions to sub statemachine. It basically ensures that substatemachine.state is collected before dispatching any action to substatemachine. 