### PR TITLE
Fix flaky on Test: actionBlockStopsWhenMovedToAnotherState

### DIFF
--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
@@ -3,6 +3,7 @@ package com.freeletics.flowredux.dsl
 import app.cash.turbine.awaitComplete
 import app.cash.turbine.awaitItem
 import app.cash.turbine.test
+import kotlinx.coroutines.Dispatchers
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -13,6 +14,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class OnActionTest {
@@ -28,8 +30,14 @@ internal class OnActionTest {
                 on<TestAction.A1> { _, state ->
                     blockEntered.send(true)
                     signal.awaitComplete()
-                    // while we wait for S2 to be emitted which cancels the block the cancelattion might happen slightly afterwards
-                    delay(100)
+                    // while we wait for S2 to be emitted which cancels this block
+                    // the cancellation of this block might happen a few milliseconds later.
+                    // Therefore we add a tiny delay and use a "real" dispatcher where delay would wait
+                    // for real (in contrast to TestDipsatcher used with runTest {...})
+                    // to avoid flakiness.
+                    withContext(Dispatchers.Default){
+                        delay(20)
+                    }
                     // this should never be reached because state transition did happen in the meantime,
                     // therefore this whole block must be canceled
                     reached = true
@@ -49,8 +57,6 @@ internal class OnActionTest {
             sm.dispatchAsync(TestAction.A2)
             assertEquals(TestState.S2, awaitItem())
             signal.close()
-            advanceUntilIdle()
-            runCurrent()
         }
 
         assertFalse(reached)

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
@@ -36,6 +36,8 @@ internal class OnActionTest {
                     // for real (in contrast to TestDipsatcher used with runTest {...})
                     // to avoid flakiness.
                     withContext(Dispatchers.Default){
+                        // 20 ms should be enough to make sure that the cancellation happened in the meantime
+                        // because of state transition to TestState.S2 in on<TestAction.A2>.
                         delay(20)
                     }
                     // this should never be reached because state transition did happen in the meantime,

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
@@ -45,7 +45,7 @@ internal class OnActionTest {
                             // because of state transition to TestState.S2 in on<TestAction.A2>.
                             delay(10)
                         }
-                        assertTrue(timeElapsed.toDouble(DurationUnit.MILLISECONDS) < 10, "Time Elapsed: $timeElapsed but expected to be < 20")
+                        assertTrue(timeElapsed.toDouble(DurationUnit.MILLISECONDS) < 10, "Time Elapsed: $timeElapsed but expected to be < 10")
                     }
                     // this should never be reached because state transition did happen in the meantime,
                     // therefore this whole block must be canceled

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/OnActionTest.kt
@@ -24,7 +24,7 @@ internal class OnActionTest {
 
     @OptIn(ExperimentalTime::class)
     @Test
-    fun actionBlockStopsWhenMovedToAnotherState() = runTest {
+    fun actionBlockStopsWhenMovedToAnotherStateWithin10Milliseconds() = runTest {
         val signal = Channel<Unit>()
         val blockEntered = Channel<Boolean>()
 
@@ -41,11 +41,11 @@ internal class OnActionTest {
                     // to avoid flakiness.
                     withContext(Dispatchers.Default) {
                         val timeElapsed = measureTime {
-                            // 20 ms should be enough to make sure that the cancellation happened in the meantime
+                            // 10 ms should be enough to make sure that the cancellation happened in the meantime
                             // because of state transition to TestState.S2 in on<TestAction.A2>.
-                            delay(20)
+                            delay(10)
                         }
-                        assertTrue(timeElapsed.toDouble(DurationUnit.MILLISECONDS) < 20, "Time Elapsed: $timeElapsed but expected to be < 20")
+                        assertTrue(timeElapsed.toDouble(DurationUnit.MILLISECONDS) < 10, "Time Elapsed: $timeElapsed but expected to be < 20")
                     }
                     // this should never be reached because state transition did happen in the meantime,
                     // therefore this whole block must be canceled


### PR DESCRIPTION
The problem with the previous implementation was that it can take a few ms for FlowRedux to cancel the `on<Action> {...}` block. therefore we have introduced the  `delay(100)` but since we did `advanceUntilIdle()` and `runCurrent()` on the `TestDispatcher` it skips the delay and it was sometimes still too fast (so cancelation happened afterward). That resulted in a flaky test.

Now I rephrased the test towards "Block is canceled within 10 milliseconds after having moved to another state"