### PR TITLE
create IsInState interface, add val for it to InStateSideEffectBuilder

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/Action.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/Action.kt
@@ -6,11 +6,11 @@ import com.freeletics.flowredux.dsl.reduce
 internal sealed class Action<S, A>
 
 internal data class ChangeStateAction<S, A>(
-    private val runReduceOnlyIf: (S) -> Boolean,
+    private val runReduceOnlyIf: InStateSideEffectBuilder.IsInState<S>,
     private val changedState: ChangedState<S>,
 ) : Action<S, A>() {
     fun reduce(state: S): S {
-        if (runReduceOnlyIf(state)) {
+        if (runReduceOnlyIf.check(state)) {
             return changedState.reduce(state)
         }
         return state

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/InStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/InStateSideEffectBuilder.kt
@@ -8,17 +8,21 @@ import com.freeletics.flowredux.SideEffect
  * Thus it's an internal abstract class but you can think of it as an internal interface.
  */
 internal abstract class InStateSideEffectBuilder<InputState : S, S, A> {
+    fun interface IsInState<S> {
+        fun check(state: S): Boolean
+    }
 
-    internal abstract fun generateSideEffect(): SideEffect<S, A>
+    abstract val isInState: IsInState<S>
 
-    internal suspend inline fun runOnlyIfInInputState(
+    abstract fun generateSideEffect(): SideEffect<S, A>
+
+    protected suspend inline fun runOnlyIfInInputState(
         getState: GetState<S>,
-        isInState: (S) -> Boolean,
         crossinline block: suspend (InputState) -> Unit,
     ) {
         val currentState = getState()
         // only start if is in state condition is still true
-        if (isInState(currentState)) {
+        if (isInState.check(currentState)) {
             val inputState = try {
                 @Suppress("UNCHECKED_CAST")
                 currentState as InputState

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnterInStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnterInStateSideEffectBuilder.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.flow
  */
 @ExperimentalCoroutinesApi
 internal class OnEnterInStateSideEffectBuilder<InputState : S, S : Any, A : Any>(
-    private val isInState: (S) -> Boolean,
+    override val isInState: IsInState<S>,
     private val handler: suspend (state: State<InputState>) -> ChangedState<S>,
 ) : InStateSideEffectBuilder<InputState, S, A>() {
 
@@ -38,12 +38,12 @@ internal class OnEnterInStateSideEffectBuilder<InputState : S, S : Any, A : Any>
     private suspend fun setStateFlow(
         getState: GetState<S>,
     ): Flow<Action<S, A>> = flow {
-        runOnlyIfInInputState(getState, isInState) { inputState ->
+        runOnlyIfInInputState(getState) { inputState ->
             val changeState = handler(State(inputState))
             emit(
                 ChangeStateAction<S, A>(
                     changedState = changeState,
-                    runReduceOnlyIf = { state -> isInState(state) },
+                    runReduceOnlyIf = { state -> isInState.check(state) },
                 ),
             )
         }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/StartStateMachineOnActionInStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/StartStateMachineOnActionInStateSideEffectBuilder.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 internal class StartStateMachineOnActionInStateSideEffectBuilder<SubStateMachineState : Any, SubStateMachineAction : Any, InputState : S, ActionThatTriggeredStartingStateMachine : A, S : Any, A : Any>(
-    private val isInState: (S) -> Boolean,
+    override val isInState: IsInState<S>,
     private val subStateMachineFactory: (
         action: ActionThatTriggeredStartingStateMachine,
         state: InputState,
@@ -49,7 +49,7 @@ internal class StartStateMachineOnActionInStateSideEffectBuilder<SubStateMachine
                                 }
 
                                 is ExternalWrappedAction<*, *> ->
-                                    runOnlyIfInInputState(getState, isInState) { currentState ->
+                                    runOnlyIfInInputState(getState) { currentState ->
                                         // TODO take ExecutionPolicy into account
                                         if (subActionClass.isInstance(action.action)) {
                                             val actionThatStartsStateMachine =
@@ -71,7 +71,7 @@ internal class StartStateMachineOnActionInStateSideEffectBuilder<SubStateMachine
                                                         subStateMachinesMap.remove(stateMachine)
                                                     }
                                                     .collect { subStateMachineState ->
-                                                        runOnlyIfInInputState(getState, isInState) { parentState ->
+                                                        runOnlyIfInInputState(getState) { parentState ->
                                                             send(
                                                                 ChangeStateAction(
                                                                     runReduceOnlyIf = isInState,

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/StartStatemachineOnEnterSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/StartStatemachineOnEnterSideEffectBuilder.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.launch
 
 @ExperimentalCoroutinesApi
 internal class StartStatemachineOnEnterSideEffectBuilder<SubStateMachineState : Any, SubStateMachineAction : Any, InputState : S, S : Any, A>(
-    private val isInState: (S) -> Boolean,
+    override val isInState: IsInState<S>,
     private val subStateMachineFactory: (InputState) -> StateMachine<SubStateMachineState, SubStateMachineAction>,
     private val actionMapper: (A) -> SubStateMachineAction?,
     private val stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S>,
@@ -93,7 +93,7 @@ internal class StartStatemachineOnEnterSideEffectBuilder<SubStateMachineState : 
                             }.mapNotNull { subStateMachineState: SubStateMachineState ->
                                 var changeStateAction: ChangeStateAction<S, A>? = null
 
-                                runOnlyIfInInputState(getState, isInState) { inputState ->
+                                runOnlyIfInInputState(getState) { inputState ->
                                     changeStateAction = ChangeStateAction<S, A>(
                                         runReduceOnlyIf = isInState,
                                         changedState = stateMapper(

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/util/MapToIsInState.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/util/MapToIsInState.kt
@@ -2,14 +2,15 @@ package com.freeletics.flowredux.util
 
 import com.freeletics.flowredux.GetState
 import com.freeletics.flowredux.sideeffects.Action
+import com.freeletics.flowredux.sideeffects.InStateSideEffectBuilder
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 internal fun <S, A> Flow<Action<S, A>>.mapToIsInState(
-    isInState: (S) -> Boolean,
+    isInState: InStateSideEffectBuilder.IsInState<S>,
     getState: GetState<S>,
 ): Flow<Boolean> {
-    return map { isInState(getState()) }
+    return map { isInState.check(getState()) }
         .distinctUntilChanged()
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/util/WhileInState.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/util/WhileInState.kt
@@ -2,6 +2,7 @@ package com.freeletics.flowredux.util
 
 import com.freeletics.flowredux.GetState
 import com.freeletics.flowredux.sideeffects.Action
+import com.freeletics.flowredux.sideeffects.InStateSideEffectBuilder
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -10,7 +11,7 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
 
 internal fun <S, A> Flow<Action<S, A>>.whileInState(
-    isInState: (S) -> Boolean,
+    isInState: InStateSideEffectBuilder.IsInState<S>,
     getState: GetState<S>,
     transform: suspend (Flow<Action<S, A>>) -> Flow<Action<S, A>>,
 ) = channelFlow {
@@ -18,7 +19,7 @@ internal fun <S, A> Flow<Action<S, A>>.whileInState(
 
     // collect upstream
     collect { value ->
-        if (isInState(getState())) {
+        if (isInState.check(getState())) {
             // if there is no Channel yet the state machine just entered the state
             if (currentChannel == null) {
                 currentChannel = Channel()


### PR DESCRIPTION
We'll need to split state checks into 2 different kinds:
- One for checking whether we should start this side effect, this will match the current checks
- The other one for whether we should terminate the side effect. For the current things this will be the same but for anything inside the identity block this will need to check that the identity of the current state is still the same as the identity of the state that started the side effect. The reason for separating `isInState` for this purpose is to avoid reimpleting all side effects again for the identity block.
To avoid mistakes I want to have 2 separate interfaces for these 2. This introduces the first one that just matches the current checks. The second one will be introduced further into the refactoring. 

`InStateSideEffectBuilder` will have this as an `abstract val` which already allows using it directly in `runOnlyIfInInputState` and will enable the next pr to share a bit more code for the side effects.