### PR TITLE
add reusable stateChange to InStateSideEffectBuilder

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectInStateBasedOnStateBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectInStateBasedOnStateBuilder.kt
@@ -31,7 +31,7 @@ internal class CollectInStateBasedOnStateBuilder<T, InputState : S, S : Any, A :
                 flowOfCurrentState(inStateActions, getState)
                     .transformWithFlowBuilder()
                     .flatMapWithExecutionPolicy(executionPolicy) { item ->
-                        stateChange(getState) { snapshot ->
+                        changeState(getState) { snapshot ->
                             handler(item, State(snapshot))
                         }
                     }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectInStateBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectInStateBuilder.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 
 /**
  * A builder to create a [SideEffect] that observes a Flow<T> as long as the redux store is in
@@ -38,7 +37,7 @@ internal class CollectInStateBuilder<T, InputState : S, S : Any, A : Any>(
                 .flatMapLatest { inState ->
                     if (inState) {
                         flow.flatMapWithExecutionPolicy(executionPolicy) { item ->
-                            stateChange(getState) { snapshot ->
+                            changeState(getState) { snapshot ->
                                 handler(item, State(snapshot))
                             }
                         }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/InStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/InStateSideEffectBuilder.kt
@@ -19,7 +19,7 @@ internal abstract class InStateSideEffectBuilder<InputState : S, S, A> {
 
     abstract fun generateSideEffect(): SideEffect<S, A>
 
-    protected inline fun stateChange(
+    protected inline fun changeState(
         crossinline getState: GetState<S>,
         crossinline block: suspend (InputState) -> ChangedState<S>,
     ): Flow<Action<S, A>> {

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/InStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/InStateSideEffectBuilder.kt
@@ -2,6 +2,9 @@ package com.freeletics.flowredux.sideeffects
 
 import com.freeletics.flowredux.GetState
 import com.freeletics.flowredux.SideEffect
+import com.freeletics.flowredux.dsl.ChangedState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 /**
  * It's just not an Interface to not expose internal class `Action` to the public.
@@ -15,6 +18,18 @@ internal abstract class InStateSideEffectBuilder<InputState : S, S, A> {
     abstract val isInState: IsInState<S>
 
     abstract fun generateSideEffect(): SideEffect<S, A>
+
+    protected inline fun stateChange(
+        crossinline getState: GetState<S>,
+        crossinline block: suspend (InputState) -> ChangedState<S>,
+    ): Flow<Action<S, A>> {
+        return flow {
+            runOnlyIfInInputState(getState) {
+                val changedState = block(it)
+                emit(ChangeStateAction(isInState, changedState))
+            }
+        }
+    }
 
     protected suspend inline fun runOnlyIfInInputState(
         getState: GetState<S>,

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnActionInStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnActionInStateSideEffectBuilder.kt
@@ -38,7 +38,7 @@ internal class OnActionInStateSideEffectBuilder<InputState : S, SubAction : A, S
                     }
                 }
                     .flatMapWithExecutionPolicy(executionPolicy) { action ->
-                        stateChange(getState) { snapshot ->
+                        changeState(getState) { snapshot ->
                             handler(action, State(snapshot))
                         }
                     }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnActionInStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnActionInStateSideEffectBuilder.kt
@@ -12,7 +12,6 @@ import com.freeletics.flowredux.util.whileInState
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.mapNotNull
 
 @ExperimentalCoroutinesApi
@@ -39,32 +38,11 @@ internal class OnActionInStateSideEffectBuilder<InputState : S, SubAction : A, S
                     }
                 }
                     .flatMapWithExecutionPolicy(executionPolicy) { action ->
-                        onActionSideEffectFactory(
-                            action = action,
-                            getState = getState,
-                        )
+                        stateChange(getState) { snapshot ->
+                            handler(action, State(snapshot))
+                        }
                     }
             }
         }
     }
-
-    private fun onActionSideEffectFactory(
-        action: SubAction,
-        getState: GetState<S>,
-    ): Flow<Action<S, A>> =
-        flow {
-            runOnlyIfInInputState(getState) { inputState ->
-                val changeState = handler(
-                    action,
-                    State(inputState),
-                )
-
-                emit(
-                    ChangeStateAction<S, A>(
-                        changedState = changeState,
-                        runReduceOnlyIf = { state -> isInState.check(state) },
-                    ),
-                )
-            }
-        }
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnterInStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnterInStateSideEffectBuilder.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 
 /**
  * A builder that generates a [SideEffect] that triggers every time the state machine enters
@@ -27,25 +26,13 @@ internal class OnEnterInStateSideEffectBuilder<InputState : S, S : Any, A : Any>
                 .mapToIsInState(isInState, getState)
                 .flatMapLatest {
                     if (it) {
-                        setStateFlow(getState)
+                        stateChange(getState) { snapshot ->
+                            handler(State(snapshot))
+                        }
                     } else {
                         emptyFlow()
                     }
                 }
-        }
-    }
-
-    private suspend fun setStateFlow(
-        getState: GetState<S>,
-    ): Flow<Action<S, A>> = flow {
-        runOnlyIfInInputState(getState) { inputState ->
-            val changeState = handler(State(inputState))
-            emit(
-                ChangeStateAction<S, A>(
-                    changedState = changeState,
-                    runReduceOnlyIf = { state -> isInState.check(state) },
-                ),
-            )
         }
     }
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnterInStateSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnterInStateSideEffectBuilder.kt
@@ -26,7 +26,7 @@ internal class OnEnterInStateSideEffectBuilder<InputState : S, S : Any, A : Any>
                 .mapToIsInState(isInState, getState)
                 .flatMapLatest {
                     if (it) {
-                        stateChange(getState) { snapshot ->
+                        changeState(getState) { snapshot ->
                             handler(State(snapshot))
                         }
                     } else {

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/StartStatemachineOnEnterSideEffectBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/StartStatemachineOnEnterSideEffectBuilder.kt
@@ -91,7 +91,7 @@ internal class StartStatemachineOnEnterSideEffectBuilder<SubStateMachineState : 
                                 // This should never be called as the full flow should be canceled.
                                 emptyFlow()
                             }.flatMapConcat { subStateMachineState ->
-                                stateChange(getState) { inputState ->
+                                changeState(getState) { inputState ->
                                     stateMapper(State(inputState), subStateMachineState)
                                 }
                             }


### PR DESCRIPTION
Similar to `runOnlyIfInInputState` we now have a reusable method to produce a flow that emits a state change in the builder. This replaces the various versions of `setStateFlow` in the subclasses.