### PR TITLE
remove ChangeStateAction

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/FlowRedux.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/FlowRedux.kt
@@ -1,62 +1,66 @@
 package com.freeletics.flowredux
 
+import com.freeletics.flowredux.dsl.reduce
 import com.freeletics.flowredux.sideeffects.Action
-import com.freeletics.flowredux.sideeffects.ChangeStateAction
 import com.freeletics.flowredux.sideeffects.ExternalWrappedAction
 import com.freeletics.flowredux.sideeffects.GetState
 import com.freeletics.flowredux.sideeffects.InitialStateAction
 import com.freeletics.flowredux.sideeffects.SideEffectBuilder
+import com.freeletics.flowredux.sideeffects.produceStateGuarded
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 
 internal fun <A : Any, S : Any> Flow<A>.reduxStore(
     initialStateSupplier: () -> S,
     sideEffectBuilders: Iterable<SideEffectBuilder<out S, S, A>>,
-): Flow<S> = flow {
+): Flow<S> = channelFlow {
     var currentState: S = initialStateSupplier()
     val getState: GetState<S> = { currentState }
 
     val sideEffects = sideEffectBuilders.map { it.build() }
 
     // Emit the initial state
-    emit(currentState)
+    send(currentState)
 
     val loopbacks = sideEffects.map {
-        Channel<Action<S, A>>()
+        Channel<Action<A>>()
     }
-    val sideEffectActions = sideEffects.mapIndexed { index, sideEffect ->
-        val actionsFlow = loopbacks[index].consumeAsFlow()
-        sideEffect.produceState(actionsFlow, getState)
-    }
-    val upstreamActions = this@reduxStore
-        .map<A, Action<S, A>> { ExternalWrappedAction(it) }
-        .onStart {
-            emit(InitialStateAction())
+
+    launch {
+        val sideEffectActions = sideEffects.mapIndexed { index, sideEffect ->
+            val actionsFlow = loopbacks[index].consumeAsFlow()
+            sideEffect.produceStateGuarded(actionsFlow, getState)
         }
 
-    (sideEffectActions + upstreamActions).merge().collect { action ->
-        // Change state
-        if (action is ChangeStateAction<S, A>) {
+        sideEffectActions.merge().collect { action ->
             val newState = action.reduce(currentState)
             if (currentState !== newState) {
                 currentState = newState
-                emit(newState)
+                send(newState)
 
                 // broadcast state change
                 loopbacks.forEach {
                     it.send(InitialStateAction())
                 }
             }
-        } else {
+        }
+    }
+
+    this@reduxStore
+        .map<A, Action<A>> { ExternalWrappedAction(it) }
+        .onStart {
+            emit(InitialStateAction())
+        }
+        .collect { action ->
             // broadcast action
             loopbacks.forEach {
                 it.send(action)
             }
         }
-    }
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/Action.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/Action.kt
@@ -1,33 +1,14 @@
 package com.freeletics.flowredux.sideeffects
 
-import com.freeletics.flowredux.dsl.ChangedState
-import com.freeletics.flowredux.dsl.reduce
+internal sealed class Action<A>
 
-internal sealed class Action<S, A>
-
-internal data class ChangeStateAction<S, A>(
-    private val runReduceOnlyIf: SideEffect.IsInState<S>,
-    private val changedState: ChangedState<S>,
-) : Action<S, A>() {
-    fun reduce(state: S): S {
-        if (runReduceOnlyIf.check(state)) {
-            return changedState.reduce(state)
-        }
-        return state
-    }
-
-    override fun toString(): String {
-        return "SetStateAction"
-    }
-}
-
-internal data class ExternalWrappedAction<S, A>(internal val action: A) : Action<S, A>() {
+internal data class ExternalWrappedAction<A>(internal val action: A) : Action<A>() {
     override fun toString(): String {
         return action.toString()
     }
 }
 
-internal class InitialStateAction<S, A> : Action<S, A>() {
+internal class InitialStateAction<A> : Action<A>() {
     override fun toString(): String {
         return "InitialStateDispatched"
     }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectWhile.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectWhile.kt
@@ -19,7 +19,7 @@ internal class CollectWhile<T, InputState : S, S : Any, A : Any>(
     private val handler: suspend (item: T, state: State<InputState>) -> ChangedState<S>,
 ) : SideEffect<InputState, S, A>() {
 
-    override fun produceState(actions: Flow<Action<S, A>>, getState: GetState<S>): Flow<ChangeStateAction<S, A>> {
+    override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {
         return actions
             .mapToIsInState(isInState, getState)
             .flatMapLatest { inState ->

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectWhileBasedOnState.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectWhileBasedOnState.kt
@@ -18,7 +18,7 @@ internal class CollectWhileBasedOnState<T, InputState : S, S : Any, A : Any>(
     private val handler: suspend (item: T, state: State<InputState>) -> ChangedState<S>,
 ) : SideEffect<InputState, S, A>() {
 
-    override fun produceState(actions: Flow<Action<S, A>>, getState: GetState<S>): Flow<ChangeStateAction<S, A>> {
+    override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {
         return actions.whileInState(isInState, getState) { inStateActions ->
             flowOfCurrentState(inStateActions, getState)
                 .transformWithFlowBuilder()
@@ -32,7 +32,7 @@ internal class CollectWhileBasedOnState<T, InputState : S, S : Any, A : Any>(
 
     @Suppress("unchecked_cast")
     private fun flowOfCurrentState(
-        actions: Flow<Action<S, A>>,
+        actions: Flow<Action<A>>,
         getState: GetState<S>,
     ): Flow<InputState> {
         // after every state change there is a guaranteed action emission so we use this

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnAction.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnAction.kt
@@ -20,16 +20,15 @@ internal class OnAction<InputState : S, SubAction : A, S : Any, A : Any>(
     internal val handler: suspend (action: SubAction, state: State<InputState>) -> ChangedState<S>,
 ) : SideEffect<InputState, S, A>() {
 
-    override fun produceState(actions: Flow<Action<S, A>>, getState: GetState<S>): Flow<ChangeStateAction<S, A>> {
+    override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {
         return actions.whileInState(isInState, getState) { inStateAction ->
             inStateAction.mapNotNull {
                 when (it) {
-                    is ExternalWrappedAction<*, *> -> if (subActionClass.isInstance(it.action)) {
+                    is ExternalWrappedAction -> if (subActionClass.isInstance(it.action)) {
                         it.action as SubAction
                     } else {
                         null
                     }
-                    is ChangeStateAction -> null
                     is InitialStateAction -> null
                 }
             }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnter.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnter.kt
@@ -14,7 +14,7 @@ internal class OnEnter<InputState : S, S : Any, A : Any>(
     private val handler: suspend (state: State<InputState>) -> ChangedState<S>,
 ) : SideEffect<InputState, S, A>() {
 
-    override fun produceState(actions: Flow<Action<S, A>>, getState: GetState<S>): Flow<ChangeStateAction<S, A>> {
+    override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {
         return actions
             .mapToIsInState(isInState, getState)
             .flatMapLatest {

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/util/MapToIsInState.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/util/MapToIsInState.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
-internal fun <S, A> Flow<Action<S, A>>.mapToIsInState(
+internal fun <S, A> Flow<Action<A>>.mapToIsInState(
     isInState: SideEffect.IsInState<S>,
     getState: GetState<S>,
 ): Flow<Boolean> {

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/util/WhileInState.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/util/WhileInState.kt
@@ -1,7 +1,7 @@
 package com.freeletics.flowredux.util
 
+import com.freeletics.flowredux.dsl.ChangedState
 import com.freeletics.flowredux.sideeffects.Action
-import com.freeletics.flowredux.sideeffects.ChangeStateAction
 import com.freeletics.flowredux.sideeffects.GetState
 import com.freeletics.flowredux.sideeffects.SideEffect
 import kotlinx.coroutines.CancellationException
@@ -11,12 +11,12 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
 
-internal fun <S, A> Flow<Action<S, A>>.whileInState(
+internal fun <S, A> Flow<Action<A>>.whileInState(
     isInState: SideEffect.IsInState<S>,
     getState: GetState<S>,
-    transform: suspend (Flow<Action<S, A>>) -> Flow<ChangeStateAction<S, A>>,
+    transform: suspend (Flow<Action<A>>) -> Flow<ChangedState<S>>,
 ) = channelFlow {
-    var currentChannel: Channel<Action<S, A>>? = null
+    var currentChannel: Channel<Action<A>>? = null
 
     // collect upstream
     collect { value ->


### PR DESCRIPTION
With this `SideEffect` will directly emit `ChangedState` instead of the action. This completely separates the input and output of side effects and makes handling them easier. `Action` also doesn't need a state type paremeter anymore. So the flow is now `A -> Action<A> -> SideEffect -> ChangedState<S> -> Reducer -> S` with the extra that the reducer sends `InitialStateAction` whenever there is a new state.

There is still wrapping in another class going on internally (see `guardWithIsInState`), if the `ChangedState` object is not a `NoStateChange`, to continue having the reduce guarded by an `isInState` check. So this is only slightly more efficient allocation wise. I think it should be possible later to directly have this inside the originally created `ChangedState`, but it will require fighting with generics a bit sine `State` which creates them only has a type parameter for `InputState` but not one for `State`.