### PR TITLE
explicitly cancel side effects before state change

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/FlowRedux.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/FlowRedux.kt
@@ -1,19 +1,14 @@
 package com.freeletics.flowredux
 
+import com.freeletics.flowredux.dsl.ChangedState
 import com.freeletics.flowredux.dsl.reduce
-import com.freeletics.flowredux.sideeffects.Action
-import com.freeletics.flowredux.sideeffects.ExternalWrappedAction
 import com.freeletics.flowredux.sideeffects.GetState
-import com.freeletics.flowredux.sideeffects.InitialStateAction
+import com.freeletics.flowredux.sideeffects.ManagedSideEffect
 import com.freeletics.flowredux.sideeffects.SideEffectBuilder
-import com.freeletics.flowredux.sideeffects.produceStateGuarded
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 
 internal fun <A : Any, S : Any> Flow<A>.reduxStore(
@@ -23,44 +18,37 @@ internal fun <A : Any, S : Any> Flow<A>.reduxStore(
     var currentState: S = initialStateSupplier()
     val getState: GetState<S> = { currentState }
 
-    val sideEffects = sideEffectBuilders.map { it.build() }
+    val stateChanges = Channel<ChangedState<S>>()
+    val sideEffects = sideEffectBuilders.map { ManagedSideEffect(it, this@channelFlow, getState, stateChanges) }
 
     // Emit the initial state
     send(currentState)
-
-    val loopbacks = sideEffects.map {
-        Channel<Action<A>>()
+    sideEffects.forEach {
+        it.sendStateChange(currentState)
     }
 
     launch {
-        val sideEffectActions = sideEffects.mapIndexed { index, sideEffect ->
-            val actionsFlow = loopbacks[index].consumeAsFlow()
-            sideEffect.produceStateGuarded(actionsFlow, getState)
-        }
-
-        sideEffectActions.merge().collect { action ->
+        stateChanges.consumeAsFlow().collect { action ->
             val newState = action.reduce(currentState)
             if (currentState !== newState) {
                 currentState = newState
+
+                sideEffects.forEach {
+                    it.cancelIfNeeded(newState)
+                }
+
                 send(newState)
 
-                // broadcast state change
-                loopbacks.forEach {
-                    it.send(InitialStateAction())
+                sideEffects.forEach {
+                    it.sendStateChange(currentState)
                 }
             }
         }
     }
 
-    this@reduxStore
-        .map<A, Action<A>> { ExternalWrappedAction(it) }
-        .onStart {
-            emit(InitialStateAction())
+    this@reduxStore.collect { action ->
+        sideEffects.forEach {
+            it.sendAction(action, currentState)
         }
-        .collect { action ->
-            // broadcast action
-            loopbacks.forEach {
-                it.send(action)
-            }
-        }
+    }
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectWhile.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectWhile.kt
@@ -17,7 +17,7 @@ internal class CollectWhile<T, InputState : S, S : Any, A : Any>(
     private val flow: Flow<T>,
     private val executionPolicy: ExecutionPolicy,
     private val handler: suspend (item: T, state: State<InputState>) -> ChangedState<S>,
-) : SideEffect<InputState, S, A>() {
+) : LegacySideEffect<InputState, S, A>() {
 
     override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {
         return actions

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectWhileBasedOnState.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/CollectWhileBasedOnState.kt
@@ -16,7 +16,7 @@ internal class CollectWhileBasedOnState<T, InputState : S, S : Any, A : Any>(
     private val flowBuilder: (Flow<InputState>) -> Flow<T>,
     private val executionPolicy: ExecutionPolicy,
     private val handler: suspend (item: T, state: State<InputState>) -> ChangedState<S>,
-) : SideEffect<InputState, S, A>() {
+) : LegacySideEffect<InputState, S, A>() {
 
     override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {
         return actions.whileInState(isInState, getState) { inStateActions ->

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnAction.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnAction.kt
@@ -18,7 +18,7 @@ internal class OnAction<InputState : S, SubAction : A, S : Any, A : Any>(
     internal val subActionClass: KClass<SubAction>,
     internal val executionPolicy: ExecutionPolicy,
     internal val handler: suspend (action: SubAction, state: State<InputState>) -> ChangedState<S>,
-) : SideEffect<InputState, S, A>() {
+) : LegacySideEffect<InputState, S, A>() {
 
     override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {
         return actions.whileInState(isInState, getState) { inStateAction ->

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnActionStartStateMachine.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnActionStartStateMachine.kt
@@ -24,7 +24,7 @@ internal class OnActionStartStateMachine<SubStateMachineState : Any, SubStateMac
     internal val subActionClass: KClass<out A>,
     private val actionMapper: (A) -> SubStateMachineAction?,
     private val stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S>,
-) : SideEffect<InputState, S, A>() {
+) : LegacySideEffect<InputState, S, A>() {
 
     @Suppress("UNCHECKED_CAST")
     override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnter.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnter.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 internal class OnEnter<InputState : S, S : Any, A : Any>(
     override val isInState: IsInState<S>,
     private val handler: suspend (state: State<InputState>) -> ChangedState<S>,
-) : SideEffect<InputState, S, A>() {
+) : LegacySideEffect<InputState, S, A>() {
 
     override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {
         return actions

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnterStartStateMachine.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnterStartStateMachine.kt
@@ -23,7 +23,7 @@ internal class OnEnterStartStateMachine<SubStateMachineState : Any, SubStateMach
     private val subStateMachineFactory: (InputState) -> StateMachine<SubStateMachineState, SubStateMachineAction>,
     private val actionMapper: (A) -> SubStateMachineAction?,
     private val stateMapper: (State<InputState>, SubStateMachineState) -> ChangedState<S>,
-) : SideEffect<InputState, S, A>() {
+) : LegacySideEffect<InputState, S, A>() {
 
     override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {
         return dispatchActionsToSubStateMachineAndCollectSubStateMachineState(actions, getState)


### PR DESCRIPTION
This is the first bigger change that thre previous refactorings prepared for. We now have a `ManagedSideEffect` that we create in the `reduxStore` for each builder. `ManagedSideEffect` can receive `sendStateChange` when a new state is there `sendAction` for actions coming from the outside and it has an explicit `cancelIfNeeded`. Internally it will use the `SideEffectBuilder.IsInState` in `sendStateChange` to start the side effect if it wasn't started yet. The `cancelIfNeeded` method will use `SideEffect.IsInState` to cancel a running side effect if we left the state (this is where the differentiation between isInState to start and to check whether still active that I mentioned before comes in). `sendAction` will also only forward actions based on `SideEffect.IsInState` and if the side effect is already running.

The `ManagedSideEffect` with it's explicit starting and `stopping` enables various improvements:
- We explicitly call `cancelIfNeeded` before we emit the new state to consumers and before we send the state change to side effects, which fixes various issues:
    - @kboyarshinov had an issue last year where a `collectWhileInState` for the old state was only cancelled after `collectWhileInState` for the new state was already started and in this case both collected from the same object and that object only expected one collector at a time.
    - Our flaky tests are all tests for cancellation. With this when you wait for the state change with `awaitItem` you can directly afterwards assert that the block of the old state got cancelled. Iwill update the tests in a separate PR because I want to show that this change still works with the current tests.
    - The state machine behavior should become a lot more predictable. Currently the internal side effect management and how they start and stop is kind of random.
- This also enables identity changes to work. When `cancelIfNeeded` is called for a state with a different identity `SideEffect.IsInState` will become false so the running side effect is cancelled. Then `sendStateChange` is called and since the `ManagedSideEffect` doesn't have an active side effect anymore it will start a new one.


An internal change related to that is that `SideEffect` now has `sendState` and `sendAction` to receive the state and the actions from the `ManagedSideEffect`. There is temporarily a new intermediate `LegacySideEffect` which implements those 2 methods and turns them into the `Flow<Action<A>>` that our side effects expect. After this PR each side effect will one by one be re-implemented to get rid of `LegacySideEffect`, `Action<A>` and the internal start/stop logic that they have built in.