### PR TITLE
update tests

### DIFF
--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/sideeffects/OnEnterEffectTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/sideeffects/OnEnterEffectTest.kt
@@ -1,6 +1,5 @@
 package com.freeletics.flowredux.sideeffects
 
-import app.cash.turbine.awaitComplete
 import app.cash.turbine.awaitItem
 import app.cash.turbine.test
 import com.freeletics.flowredux.StateMachine
@@ -8,9 +7,10 @@ import com.freeletics.flowredux.TestAction
 import com.freeletics.flowredux.TestState
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
 
@@ -19,18 +19,19 @@ internal class OnEnterEffectTest {
 
     @Test
     fun onEnterEffectBlockStopsWhenMovedToAnotherState() = runTest {
-        val signal = Channel<Unit>()
         val blockEntered = Channel<Boolean>(Channel.UNLIMITED)
+        var cancellation: Throwable? = null
 
-        var reached = false
         val sm = StateMachine {
             inState<TestState.Initial> {
                 onEnterEffect {
                     blockEntered.send(true)
-                    signal.awaitComplete()
-                    // this should never be reached because state transition did happen in the meantime,
-                    // therefore this whole block must be canceled
-                    reached = true
+                    try {
+                        awaitCancellation()
+                    } catch (t: Throwable) {
+                        cancellation = t
+                        throw t
+                    }
                 }
 
                 on<TestAction.A2> { _, state ->
@@ -44,10 +45,8 @@ internal class OnEnterEffectTest {
             assertTrue(blockEntered.awaitItem())
             sm.dispatchAsync(TestAction.A2)
             assertEquals(TestState.S2, awaitItem())
-            signal.close()
+            assertIs<StateChangeCancellationException>(cancellation)
         }
-
-        assertFalse(reached)
     }
 
     @Test


### PR DESCRIPTION
As mentioned in #508 the tests now don't need the delay/signa/reached anymore and we can directly check that cancellation happened after we get the new state.