### PR TITLE
refactor OnAction side effect

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnAction.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnAction.kt
@@ -1,12 +1,9 @@
-@file:Suppress("UNCHECKED_CAST")
-
 package com.freeletics.flowredux.sideeffects
 
 import com.freeletics.flowredux.dsl.ChangedState
 import com.freeletics.flowredux.dsl.ExecutionPolicy
 import com.freeletics.flowredux.dsl.State
 import com.freeletics.flowredux.util.flatMapWithExecutionPolicy
-import com.freeletics.flowredux.util.whileInState
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -18,25 +15,21 @@ internal class OnAction<InputState : S, SubAction : A, S : Any, A : Any>(
     internal val subActionClass: KClass<SubAction>,
     internal val executionPolicy: ExecutionPolicy,
     internal val handler: suspend (action: SubAction, state: State<InputState>) -> ChangedState<S>,
-) : LegacySideEffect<InputState, S, A>() {
+) : ActionBasedSideEffect<InputState, S, A>() {
 
-    override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {
-        return actions.whileInState(isInState, getState) { inStateAction ->
-            inStateAction.mapNotNull {
-                when (it) {
-                    is ExternalWrappedAction -> if (subActionClass.isInstance(it.action)) {
-                        it.action as SubAction
-                    } else {
-                        null
-                    }
-                    is InitialStateAction -> null
+    override fun produceState(getState: GetState<S>): Flow<ChangedState<S>> {
+        return actions.asSubAction()
+            .flatMapWithExecutionPolicy(executionPolicy) { action ->
+                changeState(getState) { inputState ->
+                    handler(action, State(inputState))
                 }
             }
-                .flatMapWithExecutionPolicy(executionPolicy) { action ->
-                    changeState(getState) { snapshot ->
-                        handler(action, State(snapshot))
-                    }
-                }
+    }
+
+    @Suppress("unchecked_cast")
+    private fun Flow<A>.asSubAction(): Flow<SubAction> {
+        return mapNotNull { action ->
+            action.takeIf { subActionClass.isInstance(it) } as? SubAction
         }
     }
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/SideEffect.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/SideEffect.kt
@@ -81,6 +81,16 @@ internal abstract class SideEffect<InputState : S, S, A> {
     }
 }
 
+internal abstract class ActionBasedSideEffect<InputState : S, S, A> : SideEffect<InputState, S, A>() {
+
+    private val actionChannel = Channel<A>()
+    protected val actions get() = actionChannel.receiveAsFlow()
+
+    override suspend fun sendAction(action: A) {
+        actionChannel.send(action)
+    }
+}
+
 internal class SideEffectBuilder<InputState : S, S, A>(
     val isInState: IsInState<S>,
     private val builder: () -> SideEffect<InputState, S, A>,


### PR DESCRIPTION
Introduces `ActionBasedSideEffect` as subclass for `SideEffect` that makes a `Flow` of actions available. `OnAction` simply filters this flow and then runs the handler on it. 

`ActionBasedSideEffect` will also be used by the 2  sub state machine side effects.