### PR TITLE
refactor OnEnter side effect

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/BaseBuilderBlock.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/BaseBuilderBlock.kt
@@ -100,9 +100,10 @@ public abstract class BaseBuilderBlock<InputState : S, S : Any, A : Any> interna
     public fun onEnter(
         handler: suspend (state: State<InputState>) -> ChangedState<S>,
     ) {
-        sideEffectBuilders += SideEffectBuilder(isInState) {
+        sideEffectBuilders += SideEffectBuilder(isInState) { initialState ->
             OnEnter(
                 isInState = sideEffectIsInState(),
+                initialState = initialState,
                 handler = handler,
             )
         }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnter.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/OnEnter.kt
@@ -2,29 +2,20 @@ package com.freeletics.flowredux.sideeffects
 
 import com.freeletics.flowredux.dsl.ChangedState
 import com.freeletics.flowredux.dsl.State
-import com.freeletics.flowredux.util.mapToIsInState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 
 @ExperimentalCoroutinesApi
 internal class OnEnter<InputState : S, S : Any, A : Any>(
     override val isInState: IsInState<S>,
+    private val initialState: InputState,
     private val handler: suspend (state: State<InputState>) -> ChangedState<S>,
-) : LegacySideEffect<InputState, S, A>() {
+) : SideEffect<InputState, S, A>() {
 
-    override fun produceState(actions: Flow<Action<A>>, getState: GetState<S>): Flow<ChangedState<S>> {
-        return actions
-            .mapToIsInState(isInState, getState)
-            .flatMapLatest {
-                if (it) {
-                    changeState(getState) { snapshot ->
-                        handler(State(snapshot))
-                    }
-                } else {
-                    emptyFlow()
-                }
-            }
+    override fun produceState(getState: GetState<S>): Flow<ChangedState<S>> {
+        return flow {
+            emit(handler(State(initialState)))
+        }
     }
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/SideEffect.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/SideEffect.kt
@@ -83,13 +83,14 @@ internal abstract class SideEffect<InputState : S, S, A> {
 
 internal class SideEffectBuilder<InputState : S, S, A>(
     val isInState: IsInState<S>,
-    private val builder: () -> SideEffect<InputState, S, A>,
+    private val builder: (InputState) -> SideEffect<InputState, S, A>,
 ) {
     fun interface IsInState<S> {
         fun check(state: S): Boolean
     }
 
-    fun build() = builder()
+    @Suppress("UNCHECKED_CAST")
+    fun build(state: S) = builder(state as InputState)
 }
 
 internal class ManagedSideEffect<InputState : S, S, A>(
@@ -105,7 +106,7 @@ internal class ManagedSideEffect<InputState : S, S, A>(
         if (builder.isInState.check(state)) {
             var current = currentlyActiveSideEffect
             if (current == null) {
-                val currentSideEffect = builder.build()
+                val currentSideEffect = builder.build(state)
                 val currentJob = scope.launch {
                     currentSideEffect.produceState(getState).collect {
                         // the side effect is in state might be more specific than the one in the builder


### PR DESCRIPTION
`ManagedSideEffect` will now pass the state that caused the side effect to start to the builder when creating the side effect. We then pass that directly to `OnEnter` which doesn't need to collect anything at all with this.

Having the `initialState` as builder parameter will also allow us to modify add the identity of the initial state to `SideEffect.IsInState` so that they can get cancelled on changes.