### PR TITLE
implement untilIdentityChanges block

### DIFF
--- a/flowredux/api/flowredux.api
+++ b/flowredux/api/flowredux.api
@@ -30,6 +30,7 @@ public final class com/freeletics/flowredux/dsl/ChangedStateKt {
 }
 
 public final class com/freeletics/flowredux/dsl/ConditionBuilderBlock : com/freeletics/flowredux/dsl/BaseBuilderBlock {
+	public final fun untilIdentityChanges (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/freeletics/flowredux/dsl/ExecutionPolicy : java/lang/Enum {
@@ -57,8 +58,12 @@ public final class com/freeletics/flowredux/dsl/FlowReduxStoreBuilder {
 	public final fun inStateWithCondition (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 }
 
+public final class com/freeletics/flowredux/dsl/IdentityBuilderBlock : com/freeletics/flowredux/dsl/BaseBuilderBlock {
+}
+
 public final class com/freeletics/flowredux/dsl/InStateBuilderBlock : com/freeletics/flowredux/dsl/BaseBuilderBlock {
 	public final fun condition (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public final fun untilIdentityChanges (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/freeletics/flowredux/dsl/State {

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/BaseBuilderBlock.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/BaseBuilderBlock.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.Flow
 public abstract class BaseBuilderBlock<InputState : S, S : Any, A : Any> internal constructor() {
 
     internal abstract val isInState: SideEffectBuilder.IsInState<S>
-    internal open fun sideEffectIsInState() = SideEffect.IsInState<S> {
+    internal open fun sideEffectIsInState(initialState: InputState) = SideEffect.IsInState<S> {
         isInState.check(it)
     }
 
@@ -48,7 +48,7 @@ public abstract class BaseBuilderBlock<InputState : S, S : Any, A : Any> interna
     ) {
         sideEffectBuilders += SideEffectBuilder(isInState) {
             OnAction(
-                isInState = sideEffectIsInState(),
+                isInState = sideEffectIsInState(it),
                 subActionClass = actionClass,
                 executionPolicy = executionPolicy,
                 handler = handler,
@@ -102,7 +102,7 @@ public abstract class BaseBuilderBlock<InputState : S, S : Any, A : Any> interna
     ) {
         sideEffectBuilders += SideEffectBuilder(isInState) { initialState ->
             OnEnter(
-                isInState = sideEffectIsInState(),
+                isInState = sideEffectIsInState(initialState),
                 initialState = initialState,
                 handler = handler,
             )
@@ -143,7 +143,7 @@ public abstract class BaseBuilderBlock<InputState : S, S : Any, A : Any> interna
     ) {
         sideEffectBuilders += SideEffectBuilder(isInState) {
             CollectWhile(
-                isInState = sideEffectIsInState(),
+                isInState = sideEffectIsInState(it),
                 flow = flow,
                 executionPolicy = executionPolicy,
                 handler = handler,
@@ -169,7 +169,7 @@ public abstract class BaseBuilderBlock<InputState : S, S : Any, A : Any> interna
     ) {
         sideEffectBuilders += SideEffectBuilder(isInState) {
             CollectWhileBasedOnState(
-                isInState = sideEffectIsInState(),
+                isInState = sideEffectIsInState(it),
                 flowBuilder = flowBuilder,
                 executionPolicy = executionPolicy,
                 handler = handler,
@@ -276,7 +276,7 @@ public abstract class BaseBuilderBlock<InputState : S, S : Any, A : Any> interna
     ) {
         sideEffectBuilders += SideEffectBuilder(isInState) { initialState ->
             OnEnterStartStateMachine(
-                isInState = sideEffectIsInState(),
+                isInState = sideEffectIsInState(initialState),
                 subStateMachine = stateMachineFactory(initialState),
                 actionMapper = actionMapper,
                 stateMapper = stateMapper,
@@ -328,7 +328,7 @@ public abstract class BaseBuilderBlock<InputState : S, S : Any, A : Any> interna
     ) {
         sideEffectBuilders += SideEffectBuilder(isInState) {
             OnActionStartStateMachine(
-                isInState = sideEffectIsInState(),
+                isInState = sideEffectIsInState(it),
                 subStateMachineFactory = stateMachineFactory,
                 subActionClass = actionClass,
                 actionMapper = actionMapper,

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/ConditionBuilderBlock.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/ConditionBuilderBlock.kt
@@ -9,6 +9,14 @@ public class ConditionBuilderBlock<InputState : S, S : Any, A : Any> internal co
     override val isInState: SideEffectBuilder.IsInState<S>,
 ) : BaseBuilderBlock<InputState, S, A>() {
 
+    /**
+     * Anything inside this block will only run while the [identity] of the current state
+     * remains the same. The `identity` is determined by the given function and uses
+     * [equals] for the comparison.
+     *
+     * When the `identity` changes anything currently running in the block is cancelled.
+     * Afterwards a the blocks are started again for the new `identity`.
+     */
     public fun untilIdentityChanges(
         identity: (InputState) -> Any,
         block: IdentityBuilderBlock<InputState, S, A>.() -> Unit,

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/ConditionBuilderBlock.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/ConditionBuilderBlock.kt
@@ -7,4 +7,14 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 @FlowReduxDsl
 public class ConditionBuilderBlock<InputState : S, S : Any, A : Any> internal constructor(
     override val isInState: SideEffectBuilder.IsInState<S>,
-) : BaseBuilderBlock<InputState, S, A>()
+) : BaseBuilderBlock<InputState, S, A>() {
+
+    public fun untilIdentityChanges(
+        identity: (InputState) -> Any,
+        block: IdentityBuilderBlock<InputState, S, A>.() -> Unit,
+    ) {
+        sideEffectBuilders += IdentityBuilderBlock<InputState, S, A>(isInState, identity)
+            .apply(block)
+            .sideEffectBuilders
+    }
+}

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/IdentityBuilderBlock.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/IdentityBuilderBlock.kt
@@ -1,0 +1,18 @@
+package com.freeletics.flowredux.dsl
+
+import com.freeletics.flowredux.sideeffects.SideEffect
+import com.freeletics.flowredux.sideeffects.SideEffectBuilder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+@ExperimentalCoroutinesApi
+@FlowReduxDsl
+public class IdentityBuilderBlock<InputState : S, S : Any, A : Any> internal constructor(
+    override val isInState: SideEffectBuilder.IsInState<S>,
+    private val identity: (InputState) -> Any,
+) : BaseBuilderBlock<InputState, S, A>() {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun sideEffectIsInState(initialState: InputState) = SideEffect.IsInState<S> {
+        isInState.check(it) && identity(initialState) == identity(it as InputState)
+    }
+}

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
@@ -9,6 +9,10 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any> internal cons
     override val isInState: SideEffectBuilder.IsInState<S>,
 ) : BaseBuilderBlock<InputState, S, A>() {
 
+    /**
+     * Allows handling certain actions or events only while an extra condition is `true`
+     * for the current state.
+     */
     public fun condition(
         condition: (InputState) -> Boolean,
         block: ConditionBuilderBlock<InputState, S, A>.() -> Unit,
@@ -19,6 +23,14 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any> internal cons
         }.apply(block).sideEffectBuilders
     }
 
+    /**
+     * Anything inside this block will only run while the [identity] of the current state
+     * remains the same. The `identity` is determined by the given function and uses
+     * [equals] for the comparison.
+     *
+     * When the `identity` changes anything currently running in the block is cancelled.
+     * Afterwards a the blocks are started again for the new `identity`.
+     */
     public fun untilIdentityChanges(
         identity: (InputState) -> Any,
         block: IdentityBuilderBlock<InputState, S, A>.() -> Unit,

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/dsl/InStateBuilderBlock.kt
@@ -18,4 +18,13 @@ public class InStateBuilderBlock<InputState : S, S : Any, A : Any> internal cons
             isInState.check(it) && condition(it as InputState)
         }.apply(block).sideEffectBuilders
     }
+
+    public fun untilIdentityChanges(
+        identity: (InputState) -> Any,
+        block: IdentityBuilderBlock<InputState, S, A>.() -> Unit,
+    ) {
+        sideEffectBuilders += IdentityBuilderBlock<InputState, S, A>(isInState, identity)
+            .apply(block)
+            .sideEffectBuilders
+    }
 }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/ConditionBlockTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/ConditionBlockTest.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
-internal class InStateBuilderBlockConditionTest {
+internal class ConditionBlockTest {
 
     @Test
     fun onActionTriggersOnlyWhileInCustomCondition() = runTest {

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/IdentityBlockTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux/dsl/IdentityBlockTest.kt
@@ -1,0 +1,219 @@
+package com.freeletics.flowredux.dsl
+
+import app.cash.turbine.test
+import com.freeletics.flowredux.StateMachine
+import com.freeletics.flowredux.TestAction
+import com.freeletics.flowredux.TestState
+import com.freeletics.flowredux.sideeffects.StateChangeCancellationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertIsNot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class IdentityBlockTest {
+
+    @Test
+    fun blockStartsWheneverIdentityChanges() = runTest {
+        var counter = 0
+
+        val gs1 = TestState.GenericState("asd", 1)
+
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                on<TestAction.A1> { _, state ->
+                    state.override { gs1 }
+                }
+            }
+
+            inState<TestState.GenericState> {
+                untilIdentityChanges({ it.anInt }) {
+                    onEnterEffect {
+                        counter++
+                    }
+                }
+
+                on<TestAction.A1> { _, state ->
+                    state.mutate { copy(anInt = anInt + 1) }
+                }
+            }
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1, awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(anInt = 2), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(anInt = 3), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(anInt = 4), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(anInt = 5), awaitItem())
+        }
+
+        assertEquals(5, counter)
+    }
+
+    @Test
+    fun blockDoesNotStartAgainIfIdentityDoesNotChange() = runTest {
+        var counter = 0
+
+        val gs1 = TestState.GenericState("asd", 1)
+
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                on<TestAction.A1> { _, state ->
+                    state.override { gs1 }
+                }
+            }
+
+            inState<TestState.GenericState> {
+                untilIdentityChanges({ it.anInt }) {
+                    onEnterEffect {
+                        counter++
+                    }
+                }
+
+                on<TestAction.A1> { _, state ->
+                    state.mutate { copy(aString = aString + "1") }
+                }
+            }
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1, awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(aString = "asd1"), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(aString = "asd11"), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(aString = "asd111"), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(aString = "asd1111"), awaitItem())
+        }
+
+        assertEquals(1, counter)
+    }
+
+    @Test
+    fun blockIsCancelledIfIdentityChanges() = runTest {
+        val cancellations = mutableListOf<Pair<Int, Throwable>>()
+
+        val gs1 = TestState.GenericState("asd", 1)
+
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                on<TestAction.A1> { _, state ->
+                    state.override { gs1 }
+                }
+            }
+
+            inState<TestState.GenericState> {
+                untilIdentityChanges({ it.anInt }) {
+                    onEnter {
+                        try {
+                            awaitCancellation()
+                        } catch (t: Throwable) {
+                            cancellations.add(it.snapshot.anInt to t)
+                            throw t
+                        }
+                    }
+                }
+
+                on<TestAction.A1> { _, state ->
+                    state.mutate { copy(anInt = anInt + 1) }
+                }
+            }
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1, awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(anInt = 2), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(anInt = 3), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(anInt = 4), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(anInt = 5), awaitItem())
+
+            assertEquals(4, cancellations.size)
+        }
+
+        assertEquals(5, cancellations.size)
+        assertEquals(1, cancellations[0].first)
+        assertIs<StateChangeCancellationException>(cancellations[0].second)
+        assertEquals(2, cancellations[1].first)
+        assertIs<StateChangeCancellationException>(cancellations[1].second)
+        assertEquals(3, cancellations[2].first)
+        assertIs<StateChangeCancellationException>(cancellations[2].second)
+        assertEquals(4, cancellations[3].first)
+        assertIs<StateChangeCancellationException>(cancellations[3].second)
+        // this last cancellation comes when the state machine shuts down
+        assertEquals(5, cancellations[4].first)
+        assertIsNot<StateChangeCancellationException>(cancellations[4].second)
+    }
+
+    @Test
+    fun blockIsNotCancelledIfIdentityDoesNotChange() = runTest {
+        val cancellations = mutableListOf<Pair<Int, Throwable>>()
+
+        val gs1 = TestState.GenericState("asd", 1)
+
+        val sm = StateMachine {
+            inState<TestState.Initial> {
+                on<TestAction.A1> { _, state ->
+                    state.override { gs1 }
+                }
+            }
+
+            inState<TestState.GenericState> {
+                untilIdentityChanges({ it.anInt }) {
+                    onEnter {
+                        try {
+                            awaitCancellation()
+                        } catch (t: Throwable) {
+                            cancellations.add(it.snapshot.anInt to t)
+                            throw t
+                        }
+                    }
+                }
+
+                on<TestAction.A1> { _, state ->
+                    state.mutate { copy(aString = aString + "1") }
+                }
+            }
+        }
+
+        sm.state.test {
+            assertEquals(TestState.Initial, awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1, awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(aString = "asd1"), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(aString = "asd11"), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(aString = "asd111"), awaitItem())
+            sm.dispatchAsync(TestAction.A1)
+            assertEquals(gs1.copy(aString = "asd1111"), awaitItem())
+
+            assertEquals(0, cancellations.size)
+        }
+
+        assertEquals(1, cancellations.size)
+        // this cancellation comes when the state machine shuts down
+        assertEquals(1, cancellations[0].first)
+        assertIsNot<StateChangeCancellationException>(cancellations[0].second)
+    }
+}


### PR DESCRIPTION
Closes #480 

With all the ground work that already happened in the refactorings this is now pretty simple. `sideEffectIsInState` where we create the `SideEffect.IsInState` based on `SideEffectBuilder.IsInState` now gets the `initialState` as parameter. The new `IdentityBuilderBlock` overrides that function and in addition to the regular isInState check will check that the identity of the given state matches the identity of the initial state. And that is pretty much it, the only other change was to add `untilIdentityChanges` to `InStateBuilderBlock` and `ConditionBuilderBlock`.
