### PR TITLE
remove sendState from side effect, rename sendStateChange

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/FlowRedux.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/FlowRedux.kt
@@ -26,7 +26,7 @@ internal fun <A : Any, S : Any> Flow<A>.reduxStore(
     // Emit the initial state
     send(currentState)
     sideEffects.forEach {
-        it.sendStateChange(currentState)
+        it.startIfNeeded(currentState)
     }
 
     val mutex = Mutex()
@@ -45,7 +45,7 @@ internal fun <A : Any, S : Any> Flow<A>.reduxStore(
                     send(newState)
 
                     sideEffects.forEach {
-                        it.sendStateChange(currentState)
+                        it.startIfNeeded(currentState)
                     }
                 }
             }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/SideEffect.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux/sideeffects/SideEffect.kt
@@ -23,8 +23,6 @@ internal abstract class SideEffect<InputState : S, S, A> {
 
     abstract fun produceState(getState: GetState<S>): Flow<ChangedState<S>>
 
-    open suspend fun sendState(state: S) {}
-
     open suspend fun sendAction(action: A) {}
 
     protected inline fun changeState(
@@ -93,7 +91,7 @@ internal class ManagedSideEffect<InputState : S, S, A>(
 
     private var currentlyActiveSideEffect: CurrentlyActiveSideEffect? = null
 
-    suspend fun sendStateChange(state: S) {
+    suspend fun startIfNeeded(state: S) {
         if (builder.isInState.check(state)) {
             var current = currentlyActiveSideEffect
             if (current == null) {
@@ -107,8 +105,6 @@ internal class ManagedSideEffect<InputState : S, S, A>(
                 current = CurrentlyActiveSideEffect(currentJob, currentSideEffect)
                 this.currentlyActiveSideEffect = current
             }
-
-            current.sideEffect.sendState(state)
         }
     }
 


### PR DESCRIPTION
With the old collectWhileInState builder being gone, none of the side effects needs to react to state changes. So `sendState` can be removed and I've renamed `sendStateChange` to `startIfNeeded` which is the only thing it does now and matches `cancelIfNeeded`