### PR TITLE
change State wrapper to be receiver of all DSL handlers

### DIFF
--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/CollectWhile.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/CollectWhile.kt
@@ -12,12 +12,12 @@ internal class CollectWhile<T, InputState : S, S : Any, A : Any>(
     override val isInState: IsInState<S>,
     private val flow: Flow<T>,
     private val executionPolicy: ExecutionPolicy,
-    private val handler: suspend (item: T, state: ChangeableState<InputState>) -> ChangedState<S>,
+    private val handler: suspend ChangeableState<InputState>.(item: T) -> ChangedState<S>,
 ) : SideEffect<InputState, S, A>() {
     override fun produceState(getState: GetState<S>): Flow<ChangedState<S>> {
         return flow.flatMapWithExecutionPolicy(executionPolicy) { item ->
             changeState(getState) { inputState ->
-                handler(item, ChangeableState(inputState))
+                ChangeableState(inputState).handler(item)
             }
         }
     }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/OnAction.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/OnAction.kt
@@ -14,13 +14,13 @@ internal class OnAction<InputState : S, SubAction : A, S : Any, A : Any>(
     override val isInState: IsInState<S>,
     internal val subActionClass: KClass<SubAction>,
     internal val executionPolicy: ExecutionPolicy,
-    internal val handler: suspend (action: SubAction, state: ChangeableState<InputState>) -> ChangedState<S>,
+    internal val handler: suspend ChangeableState<InputState>.(action: SubAction) -> ChangedState<S>,
 ) : ActionBasedSideEffect<InputState, S, A>() {
     override fun produceState(getState: GetState<S>): Flow<ChangedState<S>> {
         return actions.asSubAction()
             .flatMapWithExecutionPolicy(executionPolicy) { action ->
                 changeState(getState) { inputState ->
-                    handler(action, ChangeableState(inputState))
+                    ChangeableState(inputState).handler(action)
                 }
             }
     }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/OnActionStartStateMachine.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/OnActionStartStateMachine.kt
@@ -22,7 +22,7 @@ internal class OnActionStartStateMachine<SubStateMachineState : Any, SubStateMac
     ) -> StateMachine<SubStateMachineState, SubStateMachineAction>,
     internal val subActionClass: KClass<out A>,
     private val actionMapper: (A) -> SubStateMachineAction?,
-    private val stateMapper: (ChangeableState<InputState>, SubStateMachineState) -> ChangedState<S>,
+    private val stateMapper: ChangeableState<InputState>.(SubStateMachineState) -> ChangedState<S>,
 ) : ActionBasedSideEffect<InputState, S, A>() {
     override fun produceState(getState: GetState<S>): Flow<ChangedState<S>> {
         return channelFlow {
@@ -53,10 +53,7 @@ internal class OnActionStartStateMachine<SubStateMachineState : Any, SubStateMac
                                 }
                                 .collect { subStateMachineState ->
                                     runOnlyIfInInputState(getState) { parentState ->
-                                        val changedState = stateMapper(
-                                            ChangeableState(parentState),
-                                            subStateMachineState,
-                                        )
+                                        val changedState = ChangeableState(parentState).stateMapper(subStateMachineState)
                                         send(changedState)
                                     }
                                 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/OnEnter.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/OnEnter.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.flow
 internal class OnEnter<InputState : S, S : Any, A : Any>(
     override val isInState: IsInState<S>,
     private val initialState: InputState,
-    private val handler: suspend (state: ChangeableState<InputState>) -> ChangedState<S>,
+    private val handler: suspend ChangeableState<InputState>.() -> ChangedState<S>,
 ) : SideEffect<InputState, S, A>() {
     override fun produceState(getState: GetState<S>): Flow<ChangedState<S>> {
         return flow {

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterStartStateMachine.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterStartStateMachine.kt
@@ -17,7 +17,7 @@ internal class OnEnterStartStateMachine<SubStateMachineState : Any, SubStateMach
     override val isInState: IsInState<S>,
     private val subStateMachine: StateMachine<SubStateMachineState, SubStateMachineAction>,
     private val actionMapper: (A) -> SubStateMachineAction?,
-    private val stateMapper: (ChangeableState<InputState>, SubStateMachineState) -> ChangedState<S>,
+    private val stateMapper: ChangeableState<InputState>.(SubStateMachineState) -> ChangedState<S>,
 ) : ActionBasedSideEffect<InputState, S, A>() {
     override fun produceState(getState: GetState<S>): Flow<ChangedState<S>> {
         return channelFlow {
@@ -31,7 +31,7 @@ internal class OnEnterStartStateMachine<SubStateMachineState : Any, SubStateMach
                     .onStart { coroutineWaiter.resume() }
                     .flatMapConcat { subStateMachineState ->
                         changeState(getState) { inputState ->
-                            stateMapper(ChangeableState(inputState), subStateMachineState)
+                            ChangeableState(inputState).stateMapper(subStateMachineState)
                         }
                     }
                     .collect {

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/ConditionBlockTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/ConditionBlockTest.kt
@@ -22,23 +22,23 @@ internal class ConditionBlockTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, state ->
-                    state.override { gs1 }
+                on<TestAction.A1> {
+                    override { gs1 }
                 }
             }
 
             inState<TestState.GenericState> {
                 condition({ it.anInt == 1 }) {
-                    on<TestAction.A1> { _, state ->
+                    on<TestAction.A1> {
                         counter1++
-                        state.override { gs2 }
+                        override { gs2 }
                     }
                 }
 
                 condition({ it.anInt == 2 }) {
-                    on<TestAction.A1> { _, state ->
+                    on<TestAction.A1> {
                         counter2++
-                        state.override { TestState.S1 }
+                        override { TestState.S1 }
                     }
                 }
             }
@@ -67,8 +67,8 @@ internal class ConditionBlockTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, state ->
-                    state.override { gs1 }
+                on<TestAction.A1> {
+                    override { gs1 }
                 }
             }
 
@@ -84,14 +84,14 @@ internal class ConditionBlockTest {
                                 throw t
                             }
                         },
-                    ) { value, state ->
-                        state.override { TestState.GenericState(value.toString(), value) }
+                    ) {
+                        override { TestState.GenericState(it.toString(), it) }
                     }
                 }
 
                 condition({ it.anInt == 2 }) {
                     onEnter {
-                        return@onEnter it.override { TestState.S1 }
+                        return@onEnter override { TestState.S1 }
                     }
                 }
             }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/IdentityBlockTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/IdentityBlockTest.kt
@@ -21,8 +21,8 @@ internal class IdentityBlockTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, state ->
-                    state.override { gs1 }
+                on<TestAction.A1> {
+                    override { gs1 }
                 }
             }
 
@@ -33,8 +33,8 @@ internal class IdentityBlockTest {
                     }
                 }
 
-                on<TestAction.A1> { _, state ->
-                    state.mutate { copy(anInt = anInt + 1) }
+                on<TestAction.A1> {
+                    mutate { copy(anInt = anInt + 1) }
                 }
             }
         }
@@ -67,8 +67,8 @@ internal class IdentityBlockTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, state ->
-                    state.override { gs1 }
+                on<TestAction.A1> {
+                    override { gs1 }
                 }
             }
 
@@ -79,8 +79,8 @@ internal class IdentityBlockTest {
                     }
                 }
 
-                on<TestAction.A1> { _, state ->
-                    state.mutate { copy(aString = aString + "1") }
+                on<TestAction.A1> {
+                    mutate { copy(aString = aString + "1") }
                 }
             }
         }
@@ -111,8 +111,8 @@ internal class IdentityBlockTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, state ->
-                    state.override { gs1 }
+                on<TestAction.A1> {
+                    override { gs1 }
                 }
             }
 
@@ -123,14 +123,14 @@ internal class IdentityBlockTest {
                             signal.send(Unit)
                             awaitCancellation()
                         } catch (t: Throwable) {
-                            cancellations.add(it.snapshot.anInt to t)
+                            cancellations.add(snapshot.anInt to t)
                             throw t
                         }
                     }
                 }
 
-                on<TestAction.A1> { _, state ->
-                    state.mutate { copy(anInt = anInt + 1) }
+                on<TestAction.A1> {
+                    mutate { copy(anInt = anInt + 1) }
                 }
             }
         }
@@ -178,8 +178,8 @@ internal class IdentityBlockTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, state ->
-                    state.override { gs1 }
+                on<TestAction.A1> {
+                    override { gs1 }
                 }
             }
 
@@ -189,14 +189,14 @@ internal class IdentityBlockTest {
                         try {
                             awaitCancellation()
                         } catch (t: Throwable) {
-                            cancellations.add(it.snapshot.anInt to t)
+                            cancellations.add(snapshot.anInt to t)
                             throw t
                         }
                     }
                 }
 
-                on<TestAction.A1> { _, state ->
-                    state.mutate { copy(aString = aString + "1") }
+                on<TestAction.A1> {
+                    mutate { copy(aString = aString + "1") }
                 }
             }
         }
@@ -231,8 +231,8 @@ internal class IdentityBlockTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, state ->
-                    state.override { gs1 }
+                on<TestAction.A1> {
+                    override { gs1 }
                 }
             }
 
@@ -243,12 +243,12 @@ internal class IdentityBlockTest {
                     }
                 }
 
-                on<TestAction.A1> { _, state ->
-                    state.mutate { copy(anInt = (anInt ?: 0) + 1) }
+                on<TestAction.A1> {
+                    mutate { copy(anInt = (anInt ?: 0) + 1) }
                 }
 
-                on<TestAction.A2> { _, state ->
-                    state.mutate { copy(anInt = null) }
+                on<TestAction.A2> {
+                    mutate { copy(anInt = null) }
                 }
             }
         }
@@ -275,8 +275,8 @@ internal class IdentityBlockTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, state ->
-                    state.override { gs1 }
+                on<TestAction.A1> {
+                    override { gs1 }
                 }
             }
 
@@ -287,8 +287,8 @@ internal class IdentityBlockTest {
                     }
                 }
 
-                on<TestAction.A1> { _, state ->
-                    state.mutate { copy(aString = aString + "1") }
+                on<TestAction.A1> {
+                    mutate { copy(aString = aString + "1") }
                 }
             }
         }
@@ -319,8 +319,8 @@ internal class IdentityBlockTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, state ->
-                    state.override { gs1 }
+                on<TestAction.A1> {
+                    override { gs1 }
                 }
             }
 
@@ -331,14 +331,14 @@ internal class IdentityBlockTest {
                             signal.send(Unit)
                             awaitCancellation()
                         } catch (t: Throwable) {
-                            cancellations.add(it.snapshot.anInt to t)
+                            cancellations.add(snapshot.anInt to t)
                             throw t
                         }
                     }
                 }
 
-                on<TestAction.A1> { _, state ->
-                    state.mutate { copy(anInt = (anInt ?: 0) + 1) }
+                on<TestAction.A1> {
+                    mutate { copy(anInt = (anInt ?: 0) + 1) }
                 }
             }
         }
@@ -386,8 +386,8 @@ internal class IdentityBlockTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, state ->
-                    state.override { gs1 }
+                on<TestAction.A1> {
+                    override { gs1 }
                 }
             }
 
@@ -397,14 +397,14 @@ internal class IdentityBlockTest {
                         try {
                             awaitCancellation()
                         } catch (t: Throwable) {
-                            cancellations.add(it.snapshot.anInt to t)
+                            cancellations.add(snapshot.anInt to t)
                             throw t
                         }
                     }
                 }
 
-                on<TestAction.A1> { _, state ->
-                    state.mutate { copy(aString = aString + "1") }
+                on<TestAction.A1> {
+                    mutate { copy(aString = aString + "1") }
                 }
             }
         }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/CollectWhileEffectTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/CollectWhileEffectTest.kt
@@ -24,12 +24,12 @@ internal class CollectWhileEffectTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                collectWhileInStateEffect(values) { v, _ ->
+                collectWhileInStateEffect(values) { v ->
                     recordedValues.send(v)
                 }
 
-                collectWhileInState(stateChange) { _, state ->
-                    state.override { TestState.S1 }
+                collectWhileInState(stateChange) {
+                    override { TestState.S1 }
                 }
             }
         }
@@ -56,16 +56,16 @@ internal class CollectWhileEffectTest {
         val sm = StateMachine {
             inState<TestState.Initial> {
                 onEnter {
-                    it.override { TestState.GenericState("a", 0) }
+                    override { TestState.GenericState("a", 0) }
                 }
             }
             inState<TestState.GenericState> {
-                collectWhileInStateEffect({ initial -> values.map { "${initial.aString}$it" } }) { v, _ ->
+                collectWhileInStateEffect({ initial -> values.map { "${initial.aString}$it" } }) { v ->
                     recordedValues.send(v)
                 }
 
-                on<TestAction.A1> { _, state ->
-                    state.override { TestState.S1 }
+                on<TestAction.A1> { state ->
+                    override { TestState.S1 }
                 }
             }
         }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/CollectWhileTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/CollectWhileTest.kt
@@ -23,9 +23,9 @@ internal class CollectWhileTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                collectWhileInState(values) { v, state ->
+                collectWhileInState(values) { v ->
                     recordedValues.send(v)
-                    state.override { TestState.S1 }
+                    override { TestState.S1 }
                 }
             }
         }
@@ -50,9 +50,9 @@ internal class CollectWhileTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                collectWhileInState({ values }) { v, state ->
+                collectWhileInState({ values }) { v ->
                     recordedValues.send(v)
-                    state.override { TestState.S1 }
+                    override { TestState.S1 }
                 }
             }
         }
@@ -74,20 +74,20 @@ internal class CollectWhileTest {
     fun moveFromCollectWhileInStateToNextStateWithAction() = runTest {
         val sm = StateMachine {
             inState<TestState.Initial> {
-                collectWhileInState(flowOf(1)) { _, state ->
-                    state.override { TestState.S1 }
+                collectWhileInState(flowOf(1)) {
+                    override { TestState.S1 }
                 }
             }
 
             inState<TestState.S1> {
-                on<TestAction.A1> { _, state ->
-                    state.override { TestState.S2 }
+                on<TestAction.A1> {
+                    override { TestState.S2 }
                 }
             }
 
             inState<TestState.S2> {
-                on<TestAction.A2> { _, state ->
-                    state.override { TestState.S1 }
+                on<TestAction.A2> {
+                    override { TestState.S1 }
                 }
             }
         }
@@ -114,20 +114,20 @@ internal class CollectWhileTest {
     fun moveFromCollectWhileInStateWithBuilderToNextStateWithAction() = runTest {
         val sm = StateMachine {
             inState<TestState.Initial> {
-                collectWhileInState({ flowOf(1) }) { _, state ->
-                    state.override { TestState.S1 }
+                collectWhileInState({ flowOf(1) }) {
+                    override { TestState.S1 }
                 }
             }
 
             inState<TestState.S1> {
-                on<TestAction.A1> { _, state ->
-                    state.override { TestState.S2 }
+                on<TestAction.A1> {
+                    override { TestState.S2 }
                 }
             }
 
             inState<TestState.S2> {
-                on<TestAction.A2> { _, state ->
-                    state.override { TestState.S1 }
+                on<TestAction.A2> {
+                    override { TestState.S1 }
                 }
             }
         }
@@ -155,12 +155,12 @@ internal class CollectWhileTest {
         val sm = StateMachine {
             inState<TestState.Initial> {
                 onEnter {
-                    it.override { TestState.GenericState("", 1) }
+                    override { TestState.GenericState("", 1) }
                 }
             }
             inState<TestState.GenericState> {
-                collectWhileInState({ flowOf(it.anInt * 10) }) { value, state ->
-                    state.override {
+                collectWhileInState({ flowOf(it.anInt * 10) }) { value ->
+                    override {
                         TestState.GenericState(aString = aString + value, anInt = value)
                     }
                 }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnActionEffectTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnActionEffectTest.kt
@@ -24,7 +24,7 @@ internal class OnActionEffectTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                onActionEffect<TestAction.A1> { _, _ ->
+                onActionEffect<TestAction.A1> {
                     blockEntered.send(true)
                     try {
                         awaitCancellation()
@@ -34,8 +34,8 @@ internal class OnActionEffectTest {
                     }
                 }
 
-                on<TestAction.A2> { _, state ->
-                    state.override { TestState.S2 }
+                on<TestAction.A2> {
+                    override { TestState.S2 }
                 }
             }
         }
@@ -57,13 +57,13 @@ internal class OnActionEffectTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                onActionEffect<TestAction.A1> { _, _ ->
+                onActionEffect<TestAction.A1> {
                     triggered.send(true)
                 }
 
-                on<TestAction.A1> { _, state ->
+                on<TestAction.A1> {
                     signal.awaitComplete()
-                    state.override { TestState.S2 }
+                    override { TestState.S2 }
                 }
             }
         }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnActionStartStateMachineTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnActionStartStateMachineTest.kt
@@ -20,9 +20,9 @@ internal class OnActionStartStateMachineTest {
         val child = StateMachine(initialState = TestState.S3)
         val parentStateMachine = StateMachine {
             inState<TestState.Initial> {
-                onActionStartStateMachine<TestAction.A1, TestState>(child) { inputState, childState ->
+                onActionStartStateMachine<TestAction.A1, TestState>(child) { childState ->
                     childStateChanged++
-                    inputState.override { childState }
+                    override { childState }
                 }
             }
         }
@@ -42,9 +42,9 @@ internal class OnActionStartStateMachineTest {
         val child = StateMachine(initialState = TestState.S3)
         val parentStateMachine = StateMachine {
             inState<TestState.Initial> {
-                onActionStartStateMachine<TestAction.A1, TestState>(child) { inputState, _ ->
+                onActionStartStateMachine<TestAction.A1, TestState>(child) {
                     childStateChanged++
-                    inputState.override { TestState.S1 }
+                    override { TestState.S1 }
                 }
             }
         }
@@ -71,37 +71,37 @@ internal class OnActionStartStateMachineTest {
 
         val child = StateMachine(initialState = TestState.S3) {
             inState<TestState.S3> {
-                on<TestAction.A2> { _, state ->
+                on<TestAction.A2> {
                     childS3A2Handled++
-                    state.override {
+                    override {
                         TestState.S1
                     } // Doesn't really matter which state, parent ignores it anyway
                 }
             }
             inState<TestState.S1> {
-                on<TestAction.A2> { _, state ->
+                on<TestAction.A2> {
                     childS1A2Handled++
-                    state.override { TestState.S3 }
+                    override { TestState.S3 }
                 }
             }
         }
 
         val parentStateMachine = StateMachine(initialState = TestState.CounterState(0)) {
             inState<TestState.CounterState> {
-                onActionStartStateMachine<TestAction.A1, TestState>(child) { inputState, childState ->
+                onActionStartStateMachine<TestAction.A1, TestState>(child) { childState ->
                     childStateChanged++
                     recordedSubStates += childState
-                    inputState.mutate { copy(counter = this.counter + 1) }
+                    mutate { copy(counter = this.counter + 1) }
                 }
 
-                on<TestAction.A3> { _, state ->
-                    state.override { TestState.S3 }
+                on<TestAction.A3> {
+                    override { TestState.S3 }
                 }
             }
 
             inState<TestState.S3> {
-                on<TestAction.A2> { _, state ->
-                    state.override { TestState.S2 }
+                on<TestAction.A2> {
+                    override { TestState.S2 }
                 }
             }
         }
@@ -149,16 +149,16 @@ internal class OnActionStartStateMachineTest {
 
         val child = StateMachine(initialState = TestState.S1) {
             inState<TestState.S1> {
-                on<TestAction.A3> { _, state -> state.override { TestState.S2 } }
+                on<TestAction.A3> { override { TestState.S2 } }
             }
 
             inState<TestState.S2> {
-                on<TestAction.A2> { _, state -> state.override { TestState.S3 } }
+                on<TestAction.A2> { override { TestState.S3 } }
             }
         }
         val parent = StateMachine(initialState = initialState) {
             inState<TestState.S3> {
-                on<TestAction.A1> { _, state -> state.override { TestState.CounterState(10) } }
+                on<TestAction.A1> { override { TestState.CounterState(10) } }
             }
             inState<TestState.CounterState> {
                 onActionStartStateMachine<TestAction.A4, TestState, TestAction>(
@@ -170,12 +170,12 @@ internal class OnActionStartStateMachineTest {
                         actionMapperRecordings += it
                         it
                     },
-                    stateMapper = { inputState, subState ->
-                        stateMapperRecordings += pairOf(inputState.snapshot, subState)
+                    stateMapper = { subState ->
+                        stateMapperRecordings += pairOf(snapshot, subState)
                         if (subState is TestState.S3) {
-                            inputState.override { TestState.S3 }
+                            override { TestState.S3 }
                         } else {
-                            inputState.mutate {
+                            mutate {
                                 copy(counter = this.counter + 1)
                             }
                         }
@@ -331,9 +331,9 @@ internal class OnActionStartStateMachineTest {
 
         val child = StateMachine(initialState = TestState.S1) {
             inState<TestState> {
-                on<TestAction> { _, state ->
+                on<TestAction> {
                     childActionInvocations.send(Unit)
-                    state.noChange()
+                    noChange()
                 }
             }
         }
@@ -352,13 +352,13 @@ internal class OnActionStartStateMachineTest {
                             is TestAction.A4 -> null
                         }
                     },
-                ) { inputState, childState ->
-                    inputState.override { childState }
+                ) { childState ->
+                    override { childState }
                 }
 
-                on<TestAction> { _, state ->
+                on<TestAction> {
                     parentActionInvocations.send(Unit)
-                    state.noChange()
+                    noChange()
                 }
             }
         }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnActionTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnActionTest.kt
@@ -28,7 +28,7 @@ internal class OnActionTest {
 
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, _ ->
+                on<TestAction.A1> {
                     blockEntered.send(true)
                     try {
                         awaitCancellation()
@@ -38,8 +38,8 @@ internal class OnActionTest {
                     }
                 }
 
-                on<TestAction.A2> { _, state ->
-                    state.override { TestState.S2 }
+                on<TestAction.A2> {
+                    override { TestState.S2 }
                 }
             }
         }
@@ -58,14 +58,14 @@ internal class OnActionTest {
     fun onActionGetsTriggeredAndMovesToNextState() = runTest {
         val sm = StateMachine {
             inState<TestState.Initial> {
-                on<TestAction.A1> { _, state ->
-                    state.override { TestState.S1 }
+                on<TestAction.A1> {
+                    override { TestState.S1 }
                 }
             }
 
             inState<TestState.S1> {
-                on<TestAction.A2> { _, state ->
-                    state.override { TestState.S2 }
+                on<TestAction.A2> {
+                    override { TestState.S2 }
                 }
             }
         }
@@ -84,12 +84,12 @@ internal class OnActionTest {
         turbineScope {
             val sm = StateMachine(TestState.GenericNullableState(null, null)) {
                 inState<TestState.GenericNullableState> {
-                    on<TestAction.A1>(executionPolicy = ExecutionPolicy.ORDERED) { _, state ->
-                        state.mutate { copy(aString = "1") }
+                    on<TestAction.A1>(executionPolicy = ExecutionPolicy.ORDERED) {
+                        mutate { copy(aString = "1") }
                     }
 
-                    on<TestAction.A2>(executionPolicy = ExecutionPolicy.ORDERED) { _, state ->
-                        state.mutate { copy(anInt = 2) }
+                    on<TestAction.A2>(executionPolicy = ExecutionPolicy.ORDERED) {
+                        mutate { copy(anInt = 2) }
                     }
                 }
             }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterEffectTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterEffectTest.kt
@@ -33,8 +33,8 @@ internal class OnEnterEffectTest {
                     }
                 }
 
-                on<TestAction.A2> { _, state ->
-                    state.override { TestState.S2 }
+                on<TestAction.A2> {
+                    override { TestState.S2 }
                 }
             }
         }
@@ -56,7 +56,7 @@ internal class OnEnterEffectTest {
         val sm = StateMachine {
             inState<TestState.Initial> {
                 onEnter {
-                    it.override { TestState.GenericState("from initial", 0) }
+                    override { TestState.GenericState("from initial", 0) }
                 }
             }
 
@@ -65,9 +65,9 @@ internal class OnEnterEffectTest {
                     genericStateEffectEntered++
                 }
 
-                on<TestAction.A1> { _, state ->
+                on<TestAction.A1> {
                     a1Received++
-                    state.override { TestState.GenericState("onA1", a1Received) }
+                    override { TestState.GenericState("onA1", a1Received) }
                 }
             }
         }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterStartStateMachineTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterStartStateMachineTest.kt
@@ -41,16 +41,16 @@ internal class OnEnterStartStateMachineTest {
 
         val child = childStateMachine(initialState = TestState.S3) {
             inState<TestState.S3> {
-                on<TestAction.A1> { _, state ->
+                on<TestAction.A1> {
                     inS3onA1Action++
-                    state.override { TestState.S1 }
+                    override { TestState.S1 }
                 }
             }
 
             inState<TestState.S2> {
-                on<TestAction.A1> { _, state ->
+                on<TestAction.A1> {
                     inS2OnA1Action++
-                    state.override { TestState.S2 }
+                    override { TestState.S2 }
                 }
             }
         }
@@ -60,20 +60,20 @@ internal class OnEnterStartStateMachineTest {
                 onEnterStartStateMachine(
                     stateMachine = child,
                     actionMapper = { it },
-                ) { state, subStateMachineState ->
+                ) { subStateMachineState ->
                     receivedChildStateUpdates += subStateMachineState
-                    receivedChildStateUpdatesParentState += state.snapshot
+                    receivedChildStateUpdatesParentState += snapshot
                     if (subStateMachineState == TestState.S3) {
-                        state.noChange()
+                        noChange()
                     } else {
-                        state.override { subStateMachineState }
+                        override { subStateMachineState }
                     }
                 }
             }
 
             inState<TestState.S1> {
-                on<TestAction.A1> { _, state ->
-                    state.override { TestState.S2 }
+                on<TestAction.A1> {
+                    override { TestState.S2 }
                 }
             }
         }
@@ -120,11 +120,11 @@ internal class OnEnterStartStateMachineTest {
                         child
                     },
                     actionMapper = { it },
-                    stateMapper = { state, _ -> state.noChange() },
+                    stateMapper = { noChange() },
                 )
 
-                on<TestAction.A1> { _, state ->
-                    state.override { state.snapshot.copy(anInt = state.snapshot.anInt + 1) }
+                on<TestAction.A1> {
+                    override { snapshot.copy(anInt = snapshot.anInt + 1) }
                 }
             }
         }
@@ -169,17 +169,17 @@ internal class OnEnterStartStateMachineTest {
                         child
                     },
                     actionMapper = { it },
-                    stateMapper = { state, _ -> state.noChange() },
+                    stateMapper = { noChange() },
                 )
 
-                on<TestAction.A1> { _, state ->
-                    state.override { TestState.S2 }
+                on<TestAction.A1> {
+                    override { TestState.S2 }
                 }
             }
 
             inState<TestState.S2> {
-                on<TestAction.A2> { _, state ->
-                    state.override { TestState.S1 }
+                on<TestAction.A2> {
+                    override { TestState.S1 }
                 }
             }
         }
@@ -215,9 +215,9 @@ internal class OnEnterStartStateMachineTest {
         val parentActionInvocations = Channel<Unit>(Channel.UNLIMITED)
         val child = childStateMachine(initialState = TestState.S1) {
             inState<TestState.S1> {
-                on<TestAction.A1> { _, state ->
+                on<TestAction.A1> {
                     childActionInvocations.send(Unit)
-                    state.noChange()
+                    noChange()
                 }
             }
         }
@@ -225,12 +225,12 @@ internal class OnEnterStartStateMachineTest {
         val sm = StateMachine(initialState = TestState.S1) {
             inState<TestState.S1> {
                 onEnterStartStateMachine(child)
-                on<TestAction.A2> { _, state -> state.override { TestState.S2 } }
+                on<TestAction.A2> { override { TestState.S2 } }
             }
             inState<TestState.S2> {
-                on<TestAction.A1> { _, state ->
+                on<TestAction.A1> {
                     parentActionInvocations.send(Unit)
-                    state.noChange()
+                    noChange()
                 }
             }
         }
@@ -249,7 +249,7 @@ internal class OnEnterStartStateMachineTest {
 
             // dispatch A1 action which is part of child definition but should not be
             //  handled by child because parent not in state where delegation to child happens
-            for (i in 1..3) {
+            repeat(3) {
                 sm.dispatch(TestAction.A1)
                 assertEquals(Unit, parentActionInvocations.awaitItem())
                 assertTrue(childActionInvocations.isEmpty) // no further emissions
@@ -263,9 +263,9 @@ internal class OnEnterStartStateMachineTest {
         val parentActionInvocations = Channel<Unit>(Channel.UNLIMITED)
         val child = childStateMachine(initialState = TestState.S1) {
             inState<TestState> {
-                on<TestAction> { _, state ->
+                on<TestAction> {
                     childActionInvocations.send(Unit)
-                    state.noChange()
+                    noChange()
                 }
             }
         }
@@ -283,9 +283,9 @@ internal class OnEnterStartStateMachineTest {
                         }
                     },
                 )
-                on<TestAction> { _, state ->
+                on<TestAction> {
                     parentActionInvocations.send(Unit)
-                    state.noChange()
+                    noChange()
                 }
             }
         }
@@ -329,18 +329,18 @@ internal class OnEnterStartStateMachineTest {
             inState<TestState.S2> {
                 onEnter {
                     childOnEnterS2++
-                    it.noChange()
+                    noChange()
                 }
-                on<TestAction.A2> { _, state ->
+                on<TestAction.A2> {
                     childActionA2++
-                    state.override { TestState.S1 }
+                    override { TestState.S1 }
                 }
             }
         }
 
         val sm = StateMachine(initialState = TestState.S1) {
             inState<TestState.S1> {
-                on<TestAction.A1> { _, state -> state.override { TestState.S2 } }
+                on<TestAction.A1> { override { TestState.S2 } }
             }
             inState<TestState.S2> {
                 onEnterEffect { parentS2++ }
@@ -350,7 +350,7 @@ internal class OnEnterStartStateMachineTest {
                         child
                     },
                     actionMapper = { it },
-                    stateMapper = { state, childState -> state.override { childState } },
+                    stateMapper = { childState -> override { childState } },
                 )
             }
         }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterTest.kt
@@ -33,8 +33,8 @@ internal class OnEnterTest {
                     }
                 }
 
-                on<TestAction.A2> { _, state ->
-                    state.override { TestState.S2 }
+                on<TestAction.A2> {
+                    override { TestState.S2 }
                 }
             }
         }
@@ -56,19 +56,19 @@ internal class OnEnterTest {
         val sm = StateMachine {
             inState<TestState.Initial> {
                 onEnter {
-                    it.override { TestState.GenericState("from initial", 0) }
+                    override { TestState.GenericState("from initial", 0) }
                 }
             }
 
             inState<TestState.GenericState> {
                 onEnter {
                     genericStateEntered++
-                    it.override { TestState.GenericState("onEnter", 0) }
+                    override { TestState.GenericState("onEnter", 0) }
                 }
 
-                on<TestAction.A1> { _, state ->
+                on<TestAction.A1> {
                     a1Received++
-                    state.override { TestState.GenericState("onA1", a1Received) }
+                    override { TestState.GenericState("onA1", a1Received) }
                 }
             }
         }


### PR DESCRIPTION
All DSL handlers now have either `State<S>` or `ChangeableState<S>` as receiver to create a more uniform API and make the DSL less noisy.

Before:
```kotlin
onEnter { it.mutate { ... } }
onEnterEffect { ... }
on<Action> { action, state -> state.mutate { ... } }
onActionEffect<Action> { action, state -> ... }
// collectWhileInState etc are like the action handlers
```

After:
```kotlin
onEnter { mutate { ... } }
onEnterEffect { ... }
on<Action> { mutate { ... } }
onActionEffect<Action> { ... }
// collectWhileInState etc are like the action handlers
```

- `State` access now always happens through `this`
- Other parameters like an action are always the only parameter and can be easily accessed through `it`.
- Unused parameters can be easily ignored, previously you'd very often have `action, _ ->` for unused state snapshots, `_, state ->` for actions that don't have values or `_, _ ->` for the combination of both creating a lot of noise. This change in particular is very visible in this PR because the tests had this a lot.

