### PR TITLE
add DSL marker to State in mutators

### DIFF
--- a/flowredux/api/flowredux.api
+++ b/flowredux/api/flowredux.api
@@ -53,9 +53,6 @@ public final class com/freeletics/flowredux2/FlowReduxBuilder {
 	public final fun inState (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 }
 
-public abstract interface annotation class com/freeletics/flowredux2/FlowReduxDsl : java/lang/annotation/Annotation {
-}
-
 public abstract class com/freeletics/flowredux2/FlowReduxStateMachine : com/freeletics/khonshu/statemachine/StateMachine {
 	public fun <init> (Ljava/lang/Object;)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;)V

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/BaseBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/BaseBuilder.kt
@@ -7,6 +7,7 @@ import com.freeletics.flowredux2.sideeffects.OnEnter
 import com.freeletics.flowredux2.sideeffects.OnEnterStartStateMachine
 import com.freeletics.flowredux2.sideeffects.SideEffect
 import com.freeletics.flowredux2.sideeffects.SideEffectBuilder
+import com.freeletics.flowredux2.util.FlowReduxDsl
 import com.freeletics.khonshu.statemachine.StateMachine
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/ChangeableState.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/ChangeableState.kt
@@ -1,9 +1,12 @@
 package com.freeletics.flowredux2
 
+import com.freeletics.flowredux2.util.FlowReduxDsl
+
 /**
  * Allows access to a [snapshot] that can be used to access the current state at the time the action
  * or event happened.
  */
+@FlowReduxDsl
 public sealed class State<InputState : Any>(
     public val snapshot: InputState,
 )
@@ -26,7 +29,7 @@ public class ChangeableState<InputState : Any>(
      * [snapshot] should never be accessed within [reducer]. Use the `this` of the lambda which
      * is guaranteed to be the current state at the time of execution instead.
      */
-    public fun mutate(reducer: InputState.() -> InputState): ChangedState<InputState> {
+    public fun mutate(reducer: @FlowReduxDsl InputState.() -> InputState): ChangedState<InputState> {
         return UnsafeMutateState(reducer)
     }
 
@@ -37,7 +40,7 @@ public class ChangeableState<InputState : Any>(
      * [snapshot] should never be accessed within [reducer]. Use the `this` of the lambda which
      * is guaranteed to be the current state at the time of execution instead.
      */
-    public fun <S : Any> override(reducer: InputState.() -> S): ChangedState<S> {
+    public fun <S : Any> override(reducer: @FlowReduxDsl InputState.() -> S): ChangedState<S> {
         return UnsafeMutateState(reducer)
     }
 

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/ConditionBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/ConditionBuilder.kt
@@ -1,6 +1,7 @@
 package com.freeletics.flowredux2
 
 import com.freeletics.flowredux2.sideeffects.SideEffectBuilder
+import com.freeletics.flowredux2.util.FlowReduxDsl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @ExperimentalCoroutinesApi

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxBuilder.kt
@@ -1,6 +1,7 @@
 package com.freeletics.flowredux2
 
 import com.freeletics.flowredux2.sideeffects.SideEffectBuilder
+import com.freeletics.flowredux2.util.FlowReduxDsl
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxDsl.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxDsl.kt
@@ -1,4 +1,0 @@
-package com.freeletics.flowredux2
-
-@DslMarker
-public annotation class FlowReduxDsl

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/IdentityBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/IdentityBuilder.kt
@@ -2,6 +2,7 @@ package com.freeletics.flowredux2
 
 import com.freeletics.flowredux2.sideeffects.SideEffect
 import com.freeletics.flowredux2.sideeffects.SideEffectBuilder
+import com.freeletics.flowredux2.util.FlowReduxDsl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @ExperimentalCoroutinesApi

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/InStateBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/InStateBuilder.kt
@@ -1,6 +1,7 @@
 package com.freeletics.flowredux2
 
 import com.freeletics.flowredux2.sideeffects.SideEffectBuilder
+import com.freeletics.flowredux2.util.FlowReduxDsl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @ExperimentalCoroutinesApi

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/util/FlowReduxDsl.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/util/FlowReduxDsl.kt
@@ -1,0 +1,5 @@
+package com.freeletics.flowredux2.util
+
+@DslMarker
+@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
+internal annotation class FlowReduxDsl

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterStartStateMachineTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterStartStateMachineTest.kt
@@ -124,7 +124,7 @@ internal class OnEnterStartStateMachineTest {
                 )
 
                 on<TestAction.A1> {
-                    override { snapshot.copy(anInt = snapshot.anInt + 1) }
+                    override { copy(anInt = anInt + 1) }
                 }
             }
         }

--- a/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux2/sample/shared/PaginationStateMachine.kt
+++ b/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux2/sample/shared/PaginationStateMachine.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
- * It's called `Internal` because it is note meant to be accessed publicly as it exposes coroutines
+ * It's called `Internal` because it is not meant to be accessed publicly as it exposes coroutines
  * Flow and suspending function to dispatch.
  *
  * Instead the "wrapper class" [PaginationStateMachine] should be used which hides `Flow` etc.

--- a/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux2/sample/shared/PaginationStateMachine.kt
+++ b/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux2/sample/shared/PaginationStateMachine.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
- * It's callend `Internal` because it is note meant to be accessed publicly as it exposes coroutines
+ * It's called `Internal` because it is note meant to be accessed publicly as it exposes coroutines
  * Flow and suspending function to dispatch.
  *
  * Instead the "wrapper class" [PaginationStateMachine] should be used which hides `Flow` etc.


### PR DESCRIPTION
This will prevent 2 things

Calling a mutator inside a mutator:
```kotlin
on<Foo> {
   override {
        mutate { // fails
        }
   }
}
```

Accessing `snapshot` inside a mutator:
```kotlin
on<Foo> {
   override {
        snapshot.copy(...) // fails
   }
}
```
Especially the latter is helpful with avoiding common mistakes were a potentially outdated state is used to construct the new state instead of using the state that is passes as `this` in the mutator. It doesn't solve it completely since you could still build a new state from the snapshot outside of the mutator and then use it but better than what we had before.

Also makes the DSL marker annotation internal.