### PR TITLE
introduce FlowReduxStateMachineFactory

### DIFF
--- a/compose/api/compose.api
+++ b/compose/api/compose.api
@@ -1,6 +1,6 @@
 public final class com/freeletics/flowredux2/compose/ComposeFlowReduxStateMachineKt {
-	public static final fun rememberState (Lcom/freeletics/flowredux2/FlowReduxStateMachine;Landroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
-	public static final fun rememberStateAndDispatch (Lcom/freeletics/flowredux2/FlowReduxStateMachine;Landroidx/compose/runtime/Composer;I)Lcom/freeletics/flowredux2/compose/StateAndDispatch;
+	public static final fun rememberState (Lcom/freeletics/flowredux2/LegacyFlowReduxStateMachine;Landroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static final fun rememberStateAndDispatch (Lcom/freeletics/flowredux2/LegacyFlowReduxStateMachine;Landroidx/compose/runtime/Composer;I)Lcom/freeletics/flowredux2/compose/StateAndDispatch;
 }
 
 public final class com/freeletics/flowredux2/compose/StateAndDispatch {

--- a/compose/src/commonMain/kotlin/com/freeletics/flowredux2/compose/ComposeFlowReduxStateMachine.kt
+++ b/compose/src/commonMain/kotlin/com/freeletics/flowredux2/compose/ComposeFlowReduxStateMachine.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import com.freeletics.flowredux2.FlowReduxStateMachine
+import com.freeletics.flowredux2.LegacyFlowReduxStateMachine
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 
@@ -23,7 +24,7 @@ import kotlinx.coroutines.launch
  */
 @ExperimentalCoroutinesApi
 @Composable
-public fun <S : Any, A : Any> FlowReduxStateMachine<S, A>.rememberState(): State<S?> {
+public fun <S : Any, A : Any> LegacyFlowReduxStateMachine<S, A>.rememberState(): State<S?> {
     return produceState<S?>(initialValue = null, this) {
         state.collect { value = it }
     }
@@ -66,7 +67,7 @@ public data class StateAndDispatch<S : Any, A : Any>(
  */
 @ExperimentalCoroutinesApi
 @Composable
-public fun <S : Any, A : Any> FlowReduxStateMachine<S, A>.rememberStateAndDispatch(): StateAndDispatch<S, A> {
+public fun <S : Any, A : Any> LegacyFlowReduxStateMachine<S, A>.rememberStateAndDispatch(): StateAndDispatch<S, A> {
     val stateMachine = this
     val scope = rememberCoroutineScope()
 

--- a/flowredux/api/flowredux.api
+++ b/flowredux/api/flowredux.api
@@ -63,11 +63,16 @@ public final class com/freeletics/flowredux2/FlowReduxBuilder {
 	public final fun inState (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 }
 
-public abstract class com/freeletics/flowredux2/FlowReduxStateMachine : com/freeletics/khonshu/statemachine/StateMachine {
+public final class com/freeletics/flowredux2/FlowReduxStateMachine {
+	public final fun dispatch (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDispatchAction ()Lkotlin/jvm/functions/Function1;
+	public final fun getState ()Ljava/lang/Object;
+}
+
+public abstract class com/freeletics/flowredux2/FlowReduxStateMachineFactory {
 	public fun <init> (Ljava/lang/Object;)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;)V
-	public fun dispatch (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getState ()Lkotlinx/coroutines/flow/Flow;
+	public final fun launchIn (Lkotlinx/coroutines/CoroutineScope;)Lcom/freeletics/flowredux2/FlowReduxStateMachine;
 	protected final fun spec (Lkotlin/jvm/functions/Function1;)V
 }
 
@@ -77,6 +82,14 @@ public final class com/freeletics/flowredux2/IdentityBuilder : com/freeletics/fl
 public final class com/freeletics/flowredux2/InStateBuilder : com/freeletics/flowredux2/BaseBuilder {
 	public final fun condition (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public final fun untilIdentityChanges (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract class com/freeletics/flowredux2/LegacyFlowReduxStateMachine : com/freeletics/khonshu/statemachine/StateMachine {
+	public fun <init> (Ljava/lang/Object;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public fun dispatch (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getState ()Lkotlinx/coroutines/flow/Flow;
+	protected final fun spec (Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract class com/freeletics/flowredux2/State {

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxStateMachine.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxStateMachine.kt
@@ -1,91 +1,30 @@
 package com.freeletics.flowredux2
 
-import com.freeletics.flowredux2.sideeffects.reduxStore
-import com.freeletics.flowredux2.util.AtomicCounter
-import com.freeletics.khonshu.statemachine.StateMachine
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 
-@ExperimentalCoroutinesApi
-public abstract class FlowReduxStateMachine<S : Any, A : Any>(
-    private val initialStateSupplier: () -> S,
-) : StateMachine<S, A> {
-    public constructor(initialState: S) : this(initialStateSupplier = { initialState })
+/**
+ * A live state machine that was created by a [FlowReduxStateMachineFactory]. [state] is
+ * a container allowing either access the current state or collecting the current state.
+ * [dispatchAction] and [dispatch] can be used to send actions to the state machine.
+ */
+public class FlowReduxStateMachine<S : Any, A : Any> internal constructor(
+    private val _state: S,
+    private val inputActions: Channel<A>,
+    private val scope: CoroutineScope,
+) {
+    public val state: S
+        get() = _state
 
-    private val inputActions = Channel<A>()
-    private lateinit var outputState: Flow<S>
-
-    private val activeFlowCounter = AtomicCounter(0)
-
-    protected fun spec(specBlock: FlowReduxBuilder<S, A>.() -> Unit) {
-        if (::outputState.isInitialized) {
-            throw IllegalStateException(
-                "State machine spec has already been set. " +
-                    "It's only allowed to call spec {...} once.",
-            )
+    public val dispatchAction: (A) -> Unit = {
+        scope.launch {
+            dispatch(it)
         }
-
-        val sideEffectBuilders = FlowReduxBuilder<S, A>().apply(specBlock).sideEffectBuilders
-
-        outputState = inputActions
-            .receiveAsFlow()
-            .reduxStore(initialStateSupplier, sideEffectBuilders)
-            .onStart {
-                if (activeFlowCounter.incrementAndGet() > 1) {
-                    throw IllegalStateException(
-                        "Can not collect state more than once at the same time. Make sure the" +
-                            "previous collection is cancelled before starting a new one. " +
-                            "Collecting state in parallel would lead to subtle bugs.",
-                    )
-                }
-            }
-            .onCompletion {
-                activeFlowCounter.decrementAndGet()
-            }
+        Unit
     }
 
-    override val state: Flow<S>
-        get() {
-            checkSpecBlockSet()
-            return outputState
-        }
-
-    override suspend fun dispatch(action: A) {
-        checkSpecBlockSet()
-        if (activeFlowCounter.get() <= 0) {
-            throw IllegalStateException(
-                "Cannot dispatch action $action because state Flow of this " +
-                    "FlowReduxStateMachine is not collected yet. " +
-                    "Start collecting the state Flow before dispatching any action.",
-            )
-        }
+    public suspend fun dispatch(action: A) {
         inputActions.send(action)
-    }
-
-    private fun checkSpecBlockSet() {
-        if (!::outputState.isInitialized) {
-            throw IllegalStateException(
-                """
-                No state machine specs are defined. Did you call spec { ... } in init {...}?
-                Example usage:
-
-                class MyStateMachine : FlowReduxStateMachine<State, Action>(InitialState) {
-
-                    init{
-                        spec {
-                            inState<FooState> {
-                                on<BarAction> { ... }
-                            }
-                            ...
-                        }
-                    }
-                }
-                """.trimIndent(),
-            )
-        }
     }
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxStateMachineFactory.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxStateMachineFactory.kt
@@ -1,0 +1,64 @@
+package com.freeletics.flowredux2
+
+import com.freeletics.flowredux2.sideeffects.SideEffectBuilder
+import com.freeletics.flowredux2.sideeffects.reduxStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+
+@ExperimentalCoroutinesApi
+public abstract class FlowReduxStateMachineFactory<S : Any, A : Any>(
+    internal val initialState: () -> S,
+) {
+    public constructor(initialState: S) : this({ initialState })
+
+    internal lateinit var sideEffectBuilders: List<SideEffectBuilder<*, S, A>>
+
+    protected fun spec(specBlock: FlowReduxBuilder<S, A>.() -> Unit) {
+        if (::sideEffectBuilders.isInitialized) {
+            throw IllegalStateException(
+                "State machine spec has already been set. " +
+                    "It's only allowed to call spec {...} once.",
+            )
+        }
+        sideEffectBuilders = FlowReduxBuilder<S, A>().apply(specBlock).sideEffectBuilders
+    }
+
+    public fun launchIn(scope: CoroutineScope): FlowReduxStateMachine<StateFlow<S>, A> {
+        checkInitialized()
+
+        val inputActions = Channel<A>(Channel.BUFFERED)
+        val initialState = initialState()
+        val state = inputActions
+            .receiveAsFlow()
+            .reduxStore(initialState, sideEffectBuilders)
+            .stateIn(scope, SharingStarted.Lazily, initialState)
+
+        return FlowReduxStateMachine(state, inputActions, scope)
+    }
+
+    internal fun checkInitialized() {
+        check(!::sideEffectBuilders.isInitialized) {
+            """
+            No state machine specs are defined. Did you call spec { ... } in init {...}?
+            Example usage:
+
+            class MyStateMachine : FlowReduxStateMachineFactory<State, Action>(InitialState) {
+
+                init{
+                    spec {
+                        inState<FooState> {
+                            on<BarAction> { ... }
+                        }
+                        ...
+                    }
+                }
+            }
+            """.trimIndent()
+        }
+    }
+}

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/LegacyFlowReduxStateMachine.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/LegacyFlowReduxStateMachine.kt
@@ -1,0 +1,91 @@
+package com.freeletics.flowredux2
+
+import com.freeletics.flowredux2.sideeffects.reduxStore
+import com.freeletics.flowredux2.util.AtomicCounter
+import com.freeletics.khonshu.statemachine.StateMachine
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+
+@ExperimentalCoroutinesApi
+public abstract class LegacyFlowReduxStateMachine<S : Any, A : Any>(
+    private val initialStateSupplier: () -> S,
+) : StateMachine<S, A> {
+    public constructor(initialState: S) : this(initialStateSupplier = { initialState })
+
+    private val inputActions = Channel<A>()
+    private lateinit var outputState: Flow<S>
+
+    private val activeFlowCounter = AtomicCounter(0)
+
+    protected fun spec(specBlock: FlowReduxBuilder<S, A>.() -> Unit) {
+        if (::outputState.isInitialized) {
+            throw IllegalStateException(
+                "State machine spec has already been set. " +
+                    "It's only allowed to call spec {...} once.",
+            )
+        }
+
+        val sideEffectBuilders = FlowReduxBuilder<S, A>().apply(specBlock).sideEffectBuilders
+
+        outputState = inputActions
+            .receiveAsFlow()
+            .reduxStore(initialStateSupplier(), sideEffectBuilders)
+            .onStart {
+                if (activeFlowCounter.incrementAndGet() > 1) {
+                    throw IllegalStateException(
+                        "Can not collect state more than once at the same time. Make sure the" +
+                            "previous collection is cancelled before starting a new one. " +
+                            "Collecting state in parallel would lead to subtle bugs.",
+                    )
+                }
+            }
+            .onCompletion {
+                activeFlowCounter.decrementAndGet()
+            }
+    }
+
+    override val state: Flow<S>
+        get() {
+            checkSpecBlockSet()
+            return outputState
+        }
+
+    override suspend fun dispatch(action: A) {
+        checkSpecBlockSet()
+        if (activeFlowCounter.get() <= 0) {
+            throw IllegalStateException(
+                "Cannot dispatch action $action because state Flow of this " +
+                    "FlowReduxStateMachine is not collected yet. " +
+                    "Start collecting the state Flow before dispatching any action.",
+            )
+        }
+        inputActions.send(action)
+    }
+
+    private fun checkSpecBlockSet() {
+        if (!::outputState.isInitialized) {
+            throw IllegalStateException(
+                """
+                No state machine specs are defined. Did you call spec { ... } in init {...}?
+                Example usage:
+
+                class MyStateMachine : FlowReduxStateMachine<State, Action>(InitialState) {
+
+                    init{
+                        spec {
+                            inState<FooState> {
+                                on<BarAction> { ... }
+                            }
+                            ...
+                        }
+                    }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+}

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/ReduxStore.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/ReduxStore.kt
@@ -8,16 +8,15 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 internal fun <A : Any, S : Any> Flow<A>.reduxStore(
-    initialStateSupplier: () -> S,
+    initialState: S,
     sideEffectBuilders: Iterable<SideEffectBuilder<out S, S, A>>,
 ): Flow<S> = channelFlow {
-    var currentState: S = initialStateSupplier()
+    var currentState: S = initialState
     val getState: GetState<S> = { currentState }
 
     val stateChanges = Channel<ChangedState<S>>(Channel.UNLIMITED)

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/FlowReduxStateMachineTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/FlowReduxStateMachineTest.kt
@@ -23,7 +23,7 @@ internal class FlowReduxStateMachineTest {
 
     @Test
     fun callingSpecBlockTwiceThrowsException() {
-        val sm = object : FlowReduxStateMachine<Any, Any>(Any()) {
+        val sm = object : LegacyFlowReduxStateMachine<Any, Any>(Any()) {
             init {
                 spec { }
             }
@@ -45,7 +45,7 @@ internal class FlowReduxStateMachineTest {
 
     @Test
     fun noSpecBlockSetThrowsException() {
-        val sm = object : FlowReduxStateMachine<Any, Any>(Any()) {}
+        val sm = object : LegacyFlowReduxStateMachine<Any, Any>(Any()) {}
 
         try {
             sm.state

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/StateMachine.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/StateMachine.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.launch
 internal class StateMachine(
     initialState: TestState = TestState.Initial,
     specBlock: FlowReduxBuilder<TestState, TestAction>.() -> Unit = {},
-) : FlowReduxStateMachine<TestState, TestAction>(initialStateSupplier = { initialState }) {
+) : LegacyFlowReduxStateMachine<TestState, TestAction>(initialStateSupplier = { initialState }) {
     init {
         spec(specBlock)
     }
@@ -29,5 +29,15 @@ internal class StateMachine(
         GlobalScope.launch {
             dispatch(action)
         }
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class StateMachineFactory(
+    initialState: TestState = TestState.Initial,
+    specBlock: FlowReduxBuilder<TestState, TestAction>.() -> Unit = {},
+) : FlowReduxStateMachineFactory<TestState, TestAction>(initialState = { initialState }) {
+    init {
+        spec(specBlock)
     }
 }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/CollectWhileEffectTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/CollectWhileEffectTest.kt
@@ -36,6 +36,7 @@ internal class CollectWhileEffectTest {
             values.emit(5)
         }
     }
+
     @Test
     fun collectWhileInStateEffectStopsAfterHavingMovedToNextState() = runTest {
         val stateChange = MutableSharedFlow<Unit>()

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterEffectTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterEffectTest.kt
@@ -20,7 +20,7 @@ internal class OnEnterEffectTest {
     fun doesNotEmitState() = runTest {
         val sm = StateMachine {
             inState<TestState.Initial> {
-                onEnterEffect{
+                onEnterEffect {
                 }
             }
         }

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterStartStateMachineTest.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterStartStateMachineTest.kt
@@ -3,7 +3,7 @@ package com.freeletics.flowredux2.sideeffects
 import app.cash.turbine.awaitItem
 import app.cash.turbine.test
 import com.freeletics.flowredux2.FlowReduxBuilder
-import com.freeletics.flowredux2.FlowReduxStateMachine
+import com.freeletics.flowredux2.LegacyFlowReduxStateMachine
 import com.freeletics.flowredux2.StateMachine
 import com.freeletics.flowredux2.TestAction
 import com.freeletics.flowredux2.TestState
@@ -379,8 +379,8 @@ internal class OnEnterStartStateMachineTest {
     private fun childStateMachine(
         initialState: TestState = TestState.Initial,
         builderBlock: FlowReduxBuilder<TestState, TestAction>.() -> Unit,
-    ): FlowReduxStateMachine<TestState, TestAction> {
-        return object : FlowReduxStateMachine<TestState, TestAction>(initialState) {
+    ): LegacyFlowReduxStateMachine<TestState, TestAction> {
+        return object : LegacyFlowReduxStateMachine<TestState, TestAction>(initialState) {
             init {
                 spec(builderBlock)
             }

--- a/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux2/sample/shared/MarkAsFavoriteStateMachine.kt
+++ b/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux2/sample/shared/MarkAsFavoriteStateMachine.kt
@@ -2,7 +2,7 @@ package com.freeletics.flowredux2.sample.shared
 
 import com.freeletics.flowredux2.ChangeableState
 import com.freeletics.flowredux2.ChangedState
-import com.freeletics.flowredux2.FlowReduxStateMachine
+import com.freeletics.flowredux2.LegacyFlowReduxStateMachine
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 
@@ -10,7 +10,7 @@ import kotlinx.coroutines.delay
 class MarkAsFavoriteStateMachine(
     private val githubApi: GithubApi,
     repository: GithubRepository,
-) : FlowReduxStateMachine<GithubRepository, Action>(
+) : LegacyFlowReduxStateMachine<GithubRepository, Action>(
         initialState = repository.copy(favoriteStatus = FavoriteStatus.OPERATION_IN_PROGRESS),
     ) {
     private val favoriteStatusWhenStarting: FavoriteStatus = repository.favoriteStatus

--- a/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux2/sample/shared/PaginationStateMachine.kt
+++ b/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux2/sample/shared/PaginationStateMachine.kt
@@ -2,7 +2,7 @@ package com.freeletics.flowredux2.sample.shared
 
 import com.freeletics.flowredux2.ChangeableState
 import com.freeletics.flowredux2.ChangedState
-import com.freeletics.flowredux2.FlowReduxStateMachine
+import com.freeletics.flowredux2.LegacyFlowReduxStateMachine
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineScope
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalCoroutinesApi::class)
 class InternalPaginationStateMachine(
     private val githubApi: GithubApi,
-) : FlowReduxStateMachine<PaginationState, Action>(LoadFirstPagePaginationState) {
+) : LegacyFlowReduxStateMachine<PaginationState, Action>(LoadFirstPagePaginationState) {
     init {
         spec {
             inState<LoadFirstPagePaginationState> {


### PR DESCRIPTION
Introduces `FlowReduxStateMachineFactory` as the class to implement and write the DSL, there is a `launchIn(CoroutineScope)` method that then returns a `FlowReduxStateMachine` which holds an active (but lazily started) `StateFlow`. 

The 2 main advantages are:
- It is easier to observe an instance of the state machine in multiple places.
- The internal input actions channel is unique per `FlowReduxStateMachine` instance. This way we don't need the checks in dispatch whether the state machine is being collected. When you obtain an instance through `launchIn` it's active and you can send actions into it. In case it's not being collected right now they are buffered in the channel.

Closes #654 which was the original motivation and highlights the issue a bit more.

Notes:
- The previous `FlowReduxStateMachine` is kept as `LegacyFlowReduxStateMachine` for easier migration (for the next to points in FlowRedux itself, for consumers and for Khonshu)
- compose integration will be updated in the next PR
- sub state machines will be migrated separately, there is also #548 to consider