### PR TITLE
add state saving mechanisms to StateMachine

### DIFF
--- a/flowredux/api/flowredux.api
+++ b/flowredux/api/flowredux.api
@@ -86,10 +86,17 @@ public final class com/freeletics/flowredux2/FlowReduxStateMachine {
 
 public abstract class com/freeletics/flowredux2/FlowReduxStateMachineFactory {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/Object;)V
-	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public static final field Companion Lcom/freeletics/flowredux2/FlowReduxStateMachineFactory$Companion;
+	public fun <init> (Lcom/freeletics/flowredux2/StateHolder;)V
 	public final fun launchIn (Lkotlinx/coroutines/CoroutineScope;)Lcom/freeletics/flowredux2/FlowReduxStateMachine;
 	protected final fun spec (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class com/freeletics/flowredux2/FlowReduxStateMachineFactory$Companion {
+	public final fun inMemoryStateHolder (Ljava/lang/Object;)Lcom/freeletics/flowredux2/StateHolder;
+	public final fun inMemoryStateHolder (Lkotlin/jvm/functions/Function0;)Lcom/freeletics/flowredux2/StateHolder;
+	public final fun lossyStateHolder (Ljava/lang/Object;)Lcom/freeletics/flowredux2/StateHolder;
+	public final fun lossyStateHolder (Lkotlin/jvm/functions/Function0;)Lcom/freeletics/flowredux2/StateHolder;
 }
 
 public final class com/freeletics/flowredux2/IdentityBuilder : com/freeletics/flowredux2/BaseBuilder {
@@ -111,9 +118,22 @@ public abstract class com/freeletics/flowredux2/LegacyFlowReduxStateMachine : co
 	protected final fun spec (Lkotlin/jvm/functions/Function1;)V
 }
 
+public abstract interface class com/freeletics/flowredux2/SaveableState {
+	public fun save (Landroidx/lifecycle/SavedStateHandle;)V
+}
+
+public final class com/freeletics/flowredux2/SaveableStateHolderKt {
+	public static final fun savedStateHandleStateHolder (Landroidx/lifecycle/SavedStateHandle;Lkotlin/jvm/functions/Function1;)Lcom/freeletics/flowredux2/StateHolder;
+	public static final fun serializableStateHolder (Landroidx/lifecycle/SavedStateHandle;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function0;)Lcom/freeletics/flowredux2/StateHolder;
+}
+
 public abstract class com/freeletics/flowredux2/State {
 	public static final field $stable I
 	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getSnapshot ()Ljava/lang/Object;
+}
+
+public abstract class com/freeletics/flowredux2/StateHolder {
+	public static final field $stable I
 }
 

--- a/flowredux/api/flowredux.api
+++ b/flowredux/api/flowredux.api
@@ -88,6 +88,8 @@ public abstract class com/freeletics/flowredux2/FlowReduxStateMachineFactory {
 	public static final field $stable I
 	public static final field Companion Lcom/freeletics/flowredux2/FlowReduxStateMachineFactory$Companion;
 	public fun <init> (Lcom/freeletics/flowredux2/StateHolder;)V
+	public fun <init> (Ljava/lang/Object;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
 	public final fun launchIn (Lkotlinx/coroutines/CoroutineScope;)Lcom/freeletics/flowredux2/FlowReduxStateMachine;
 	protected final fun spec (Lkotlin/jvm/functions/Function1;)V
 }

--- a/flowredux/flowredux.gradle.kts
+++ b/flowredux/flowredux.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
 
         listOf(
             "jvmMain",
+            "main",
             "jsMain",
             "nativeMain",
             "wasmJsMain",
@@ -38,6 +39,7 @@ dependencies {
     commonMainApi(libs.coroutines.core)
     commonMainApi(libs.statemachine)
     "composeMainApi"(libs.jetbrains.compose.runtime)
+    "composeMainCompileOnly"(libs.androidx.viewmodel.savedstate)
 
     commonTestImplementation(libs.kotlin.test)
     commonTestImplementation(libs.kotlin.test.annotations)

--- a/flowredux/src/androidMain/kotlin/com/freeletics/flowredux2/AndroidSavedStateHolder.kt
+++ b/flowredux/src/androidMain/kotlin/com/freeletics/flowredux2/AndroidSavedStateHolder.kt
@@ -1,0 +1,21 @@
+package com.freeletics.flowredux2
+
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+
+public fun <S : Parcelable> parcelableStateHolder(savedStateHandle: SavedStateHandle, initialState: () -> S): StateHolder<S> {
+    return ParcelableSavedStateHandleStateHolder(savedStateHandle, initialState)
+}
+
+private class ParcelableSavedStateHandleStateHolder<S : Parcelable>(
+    private val savedStateHandle: SavedStateHandle,
+    private val initialState: () -> S,
+) : StateHolder<S>() {
+    override fun getState(): S {
+        return savedStateHandle[STATE] ?: initialState()
+    }
+
+    override fun saveState(s: S) {
+        savedStateHandle[STATE] = s
+    }
+}

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxStateMachineFactory.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxStateMachineFactory.kt
@@ -7,15 +7,14 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 
 @ExperimentalCoroutinesApi
 public abstract class FlowReduxStateMachineFactory<S : Any, A : Any>(
-    internal val initialState: () -> S,
+    internal val stateHolder: StateHolder<S>,
 ) {
-    public constructor(initialState: S) : this({ initialState })
-
     internal lateinit var sideEffectBuilders: List<SideEffectBuilder<*, S, A>>
 
     protected fun spec(specBlock: FlowReduxBuilder<S, A>.() -> Unit) {
@@ -32,10 +31,11 @@ public abstract class FlowReduxStateMachineFactory<S : Any, A : Any>(
         checkInitialized()
 
         val inputActions = Channel<A>(Channel.BUFFERED)
-        val initialState = initialState()
+        val initialState = stateHolder.getState()
         val state = inputActions
             .receiveAsFlow()
             .reduxStore(initialState, sideEffectBuilders)
+            .onEach { stateHolder.saveState(it) }
             .stateIn(scope, SharingStarted.Lazily, initialState)
 
         return FlowReduxStateMachine(state, inputActions, scope)
@@ -60,5 +60,51 @@ public abstract class FlowReduxStateMachineFactory<S : Any, A : Any>(
             }
             """.trimIndent()
         }
+    }
+
+    public companion object {
+        public fun <S : Any> lossyStateHolder(initialState: S): StateHolder<S> {
+            return LossyStateHolder({ initialState })
+        }
+
+        public fun <S : Any> lossyStateHolder(initialState: () -> S): StateHolder<S> {
+            return LossyStateHolder(initialState)
+        }
+
+        public fun <S : Any> inMemoryStateHolder(initialState: S): StateHolder<S> {
+            return InMemoryStateHolder({ initialState })
+        }
+
+        public fun <S : Any> inMemoryStateHolder(initialState: () -> S): StateHolder<S> {
+            return InMemoryStateHolder(initialState)
+        }
+    }
+}
+
+public abstract class StateHolder<S : Any> internal constructor() {
+    internal abstract fun getState(): S
+
+    internal abstract fun saveState(s: S)
+}
+
+private class LossyStateHolder<S : Any>(
+    private val initialState: () -> S,
+) : StateHolder<S>() {
+    override fun getState(): S = initialState()
+
+    override fun saveState(s: S) {}
+}
+
+private class InMemoryStateHolder<S : Any>(
+    private val initialState: () -> S,
+) : StateHolder<S>() {
+    private var state: S? = null
+
+    override fun getState(): S {
+        return state ?: initialState().also { state = it }
+    }
+
+    override fun saveState(s: S) {
+        state = s
     }
 }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxStateMachineFactory.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxStateMachineFactory.kt
@@ -15,6 +15,9 @@ import kotlinx.coroutines.flow.stateIn
 public abstract class FlowReduxStateMachineFactory<S : Any, A : Any>(
     internal val stateHolder: StateHolder<S>,
 ) {
+    public constructor(state: S) : this(inMemoryStateHolder(state))
+    public constructor(stateSupplier: () -> S) : this(inMemoryStateHolder(stateSupplier))
+
     internal lateinit var sideEffectBuilders: List<SideEffectBuilder<*, S, A>>
 
     protected fun spec(specBlock: FlowReduxBuilder<S, A>.() -> Unit) {

--- a/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/StateMachine.kt
+++ b/flowredux/src/commonTest/kotlin/com/freeletics/flowredux2/StateMachine.kt
@@ -36,7 +36,7 @@ internal class StateMachine(
 internal class StateMachineFactory(
     initialState: TestState = TestState.Initial,
     specBlock: FlowReduxBuilder<TestState, TestAction>.() -> Unit = {},
-) : FlowReduxStateMachineFactory<TestState, TestAction>(initialState = { initialState }) {
+) : FlowReduxStateMachineFactory<TestState, TestAction>(lossyStateHolder(initialState)) {
     init {
         spec(specBlock)
     }

--- a/flowredux/src/composeMain/kotlin/com/freeletics/flowredux2/ComposeFlowReduxStateMachine.kt
+++ b/flowredux/src/composeMain/kotlin/com/freeletics/flowredux2/ComposeFlowReduxStateMachine.kt
@@ -6,10 +6,12 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import com.freeletics.flowredux2.FlowReduxStateMachineFactory.Companion.lossyStateHolder
 import com.freeletics.flowredux2.sideeffects.SideEffectBuilder
 import com.freeletics.flowredux2.sideeffects.reduxStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 
 @ExperimentalCoroutinesApi
@@ -22,26 +24,27 @@ public fun <S : Any, A : Any> stateMachine(
         FlowReduxBuilder<S, A>().apply(specBlock).sideEffectBuilders
     }
 
-    return stateMachine({ initialState }, sideEffectBuilders)
+    return stateMachine(lossyStateHolder(initialState), sideEffectBuilders)
 }
 
 @ExperimentalCoroutinesApi
 @Composable
 public fun <S : Any, A : Any> FlowReduxStateMachineFactory<S, A>.produceStateMachine(): FlowReduxStateMachine<State<S>, A> {
     checkInitialized()
-    return stateMachine(initialState, sideEffectBuilders)
+    return stateMachine(stateHolder, sideEffectBuilders)
 }
 
 @Composable
 internal fun <S : Any, A : Any> stateMachine(
-    initialState: () -> S,
+    stateHolder: StateHolder<S>,
     sideEffectBuilders: List<SideEffectBuilder<*, S, A>>,
 ): FlowReduxStateMachine<State<S>, A> {
     val inputActions = remember(sideEffectBuilders) { Channel<A>() }
-    val state = produceState(initialState(), sideEffectBuilders, inputActions) {
+    val state = produceState(stateHolder.getState(), sideEffectBuilders, inputActions) {
         inputActions
             .receiveAsFlow()
             .reduxStore(value, sideEffectBuilders)
+            .onEach { stateHolder.saveState(it) }
             .collect { value = it }
     }
 

--- a/flowredux/src/composeMain/kotlin/com/freeletics/flowredux2/ComposeFlowReduxStateMachine.kt
+++ b/flowredux/src/composeMain/kotlin/com/freeletics/flowredux2/ComposeFlowReduxStateMachine.kt
@@ -27,7 +27,7 @@ public fun <S : Any, A : Any> stateMachine(
     return stateMachine(lossyStateHolder(initialState), sideEffectBuilders)
 }
 
-@ExperimentalCoroutinesApi
+@OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 public fun <S : Any, A : Any> FlowReduxStateMachineFactory<S, A>.produceStateMachine(): FlowReduxStateMachine<State<S>, A> {
     checkInitialized()

--- a/flowredux/src/composeMain/kotlin/com/freeletics/flowredux2/SaveableStateHolder.kt
+++ b/flowredux/src/composeMain/kotlin/com/freeletics/flowredux2/SaveableStateHolder.kt
@@ -1,0 +1,57 @@
+package com.freeletics.flowredux2
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.savedstate.SavedState
+import androidx.savedstate.serialization.decodeFromSavedState
+import androidx.savedstate.serialization.encodeToSavedState
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+public fun <S : SaveableState> savedStateHandleStateHolder(savedStateHandle: SavedStateHandle, initialState: (SavedStateHandle) -> S): StateHolder<S> {
+    return SavedStateHandleStateHolder(savedStateHandle, initialState)
+}
+
+public inline fun <reified S : Any> serializableStateHolder(savedStateHandle: SavedStateHandle, noinline initialState: () -> S): StateHolder<S> {
+    return serializableStateHolder(savedStateHandle, serializer<S>(), initialState)
+}
+
+@PublishedApi
+internal fun <S : Any> serializableStateHolder(savedStateHandle: SavedStateHandle, serializer: KSerializer<S>, initialState: () -> S): StateHolder<S> {
+    return SerializableSavedStateHandleStateHolder(savedStateHandle, serializer, initialState)
+}
+
+public interface SaveableState {
+    public fun save(savedStateHandle: SavedStateHandle) {}
+}
+
+private class SavedStateHandleStateHolder<S : SaveableState>(
+    private val savedStateHandle: SavedStateHandle,
+    private val initialState: (SavedStateHandle) -> S,
+) : StateHolder<S>() {
+    private var state: S? = null
+
+    override fun getState(): S {
+        return state ?: initialState(savedStateHandle).also { state = it }
+    }
+
+    override fun saveState(s: S) {
+        s.save(savedStateHandle)
+        state = s
+    }
+}
+
+private class SerializableSavedStateHandleStateHolder<S : Any>(
+    private val savedStateHandle: SavedStateHandle,
+    private val serializer: KSerializer<S>,
+    private val initialState: () -> S,
+) : StateHolder<S>() {
+    override fun getState(): S {
+        return savedStateHandle.get<SavedState>(STATE)?.let { decodeFromSavedState(serializer, it) } ?: initialState()
+    }
+
+    override fun saveState(s: S) {
+        savedStateHandle[STATE] = encodeToSavedState(serializer, s)
+    }
+}
+
+internal const val STATE = "com.freeletics.flowredux2.STATE"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-lifecycle = { module = "androidx.lifecycle:lifecycle-common", version.ref = "androidx-lifecycle" }
 androidx-livedata = { module = "androidx.lifecycle:lifecycle-livedata-core", version.ref = "androidx-lifecycle" }
 androidx-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-viewmodel-savedstate = { module = "androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "androidx-lifecycle" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
 
 material = { module = "com.google.android.material:material", version.ref = "material" }

--- a/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux2/sample/shared/PaginationStateMachine.kt
+++ b/sample/shared_code/src/commonMain/kotlin/com/freeletics/flowredux2/sample/shared/PaginationStateMachine.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalCoroutinesApi::class)
 class InternalPaginationStateMachineFactory(
     private val githubApi: GithubApi,
-) : FlowReduxStateMachineFactory<PaginationState, Action>(LoadFirstPagePaginationState) {
+) : FlowReduxStateMachineFactory<PaginationState, Action>(lossyStateHolder(LoadFirstPagePaginationState)) {
     init {
         spec {
             inState<LoadFirstPagePaginationState> {


### PR DESCRIPTION
Brings our internal state machine subclasses into the open. Instead of being an extra class this is now built directly into `FlowReduxStateMachineFactory` and allows having state machines that
- behave like right now and always start from the given initial state (`lossyStateHolder`)
- start from the last observed state (`inMemoryStateHolder`)
- start from a state saved to a `SavedStateHandle` (`savedStateHandleStateHolder `, `serializableStateHolder`, `parcelableStateHolder`)

I first thought about making one of these the default but it's hard to choose between `lossyStateHolder` and `inMemoryStateHolder`.

Example:
```
class MyFactory(...) : FlowReduxStateMachineFactory(lossyStateHolder(InitialState)) {}
```