### PR TITLE
fix build warning for source set dependency and compileOnly dependency

### DIFF
--- a/flowredux/flowredux.gradle.kts
+++ b/flowredux/flowredux.gradle.kts
@@ -31,8 +31,6 @@ kotlin {
                 get(it).dependsOn(compose)
             }
         }
-
-        get("androidMain").dependsOn(get("jvmMain"))
     }
 }
 

--- a/flowredux/src/androidMain/kotlin/com/freeletics/flowredux2/util/AtomicCounter.kt
+++ b/flowredux/src/androidMain/kotlin/com/freeletics/flowredux2/util/AtomicCounter.kt
@@ -1,0 +1,13 @@
+package com.freeletics.flowredux2.util
+
+import java.util.concurrent.atomic.AtomicInteger
+
+internal actual class AtomicCounter actual constructor(initialValue: Int) {
+    private val atomicInt: AtomicInteger = AtomicInteger(initialValue)
+
+    actual fun get(): Int = atomicInt.get()
+
+    actual fun incrementAndGet(): Int = atomicInt.incrementAndGet()
+
+    actual fun decrementAndGet(): Int = atomicInt.decrementAndGet()
+}

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxStateMachineFactory.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/FlowReduxStateMachineFactory.kt
@@ -5,7 +5,6 @@ import com.freeletics.flowredux2.sideeffects.reduxStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ org.gradle.parallel=true
 android.useAndroidX=true
 
 kotlin.native.ignoreDisabledTargets=true
+kotlin.suppressGradlePluginWarnings=IncorrectCompileOnlyDependencyWarning
 
 fgp.defaultPackageName=com.freeletics.flowredux2
 fgp.kotlin.warningsAsErrors=false


### PR DESCRIPTION
- Fixes warning that `androidMain` shouldn't depend on `jvmMain` by removing the dependency. Because of that I needed to create a copy of `AtomicCounter`. The alternative would have been to create a shared source set and make both `jvmMain` and `androidMain` depend on it. Just for one class it's not worth it though and the class will also go away once the atomic APIs in the stdlib go stable.
- Suppresses the warning for `IncorrectCompileOnlyDependencyWarning` because we intentionally do the `compileOnly` dependency even if it's not supported for Kotlin/Native and JS. We expect Kotlin consumers of this library that use `SavedStateHandle` to bring in the dependency.