### PR TITLE
add onEnterLoadSmoothly variant with LoadingState interface

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.android.library).apply(false)
     alias(libs.plugins.compose).apply(false)
     alias(libs.plugins.dependency.analysis).apply(false)
+    alias(libs.plugins.burst).apply(false)
     alias(libs.plugins.dokka).apply(false)
     alias(libs.plugins.publish).apply(false)
 

--- a/flowredux-extensions/api/flowredux-extensions.api
+++ b/flowredux-extensions/api/flowredux-extensions.api
@@ -1,4 +1,11 @@
+public abstract interface class com/freeletics/flowredux2/extensions/LoadingState {
+	public abstract fun getShowLoadingIndicator ()Z
+	public abstract fun withShowLoadingIndicatorEnabled ()Lcom/freeletics/flowredux2/extensions/LoadingState;
+}
+
 public final class com/freeletics/flowredux2/extensions/OnEnterLoadSmoothlyKt {
+	public static final fun getDefaultLoadingIndicatorDelay ()J
+	public static final fun getDefaultMinimumLoadingIndicatorDisplayTime ()J
 	public static final fun onEnterLoadSmoothly-2AWqQcw (Lcom/freeletics/flowredux2/BaseBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;JJLkotlin/time/TimeSource$WithComparableMarks;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun onEnterLoadSmoothly-2AWqQcw$default (Lcom/freeletics/flowredux2/BaseBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;JJLkotlin/time/TimeSource$WithComparableMarks;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 }

--- a/flowredux-extensions/flowredux-extensions.gradle.kts
+++ b/flowredux-extensions/flowredux-extensions.gradle.kts
@@ -1,6 +1,10 @@
+import kotlin.jvm.java
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     id("com.freeletics.gradle.multiplatform")
     id("com.freeletics.gradle.publish.oss")
+    id("app.cash.burst")
 }
 
 freeletics {
@@ -18,4 +22,11 @@ dependencies {
     commonTestImplementation(libs.kotlin.test.annotations)
     commonTestImplementation(libs.turbine)
     commonTestImplementation(libs.coroutines.test)
+}
+
+// see the @Suppress("INVISIBLE_REFERENCE")
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    this.compilerOptions {
+        freeCompilerArgs.add("-Xdont-warn-on-error-suppression")
+    }
 }

--- a/flowredux-extensions/src/commonMain/kotlin/com/freeletics/flowredux2/extensions/OnEnterLoadSmoothly.kt
+++ b/flowredux-extensions/src/commonMain/kotlin/com/freeletics/flowredux2/extensions/OnEnterLoadSmoothly.kt
@@ -10,8 +10,11 @@ import kotlin.time.measureTimedValue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 
-private val defaultLoadingIndicatorDelay = 500L.milliseconds
-private val defaultMinimumLoadingIndicatorDisplayTime = 500L.milliseconds
+@PublishedApi
+internal val defaultLoadingIndicatorDelay: Duration = 500L.milliseconds
+
+@PublishedApi
+internal val defaultMinimumLoadingIndicatorDisplayTime: Duration = 500L.milliseconds
 
 /**
  * A custom [BaseBuilder.onEnter] implementation to load data.

--- a/flowredux-extensions/src/commonMain/kotlin/com/freeletics/flowredux2/extensions/OnEnterLoadSmoothlyLoadingState.kt
+++ b/flowredux-extensions/src/commonMain/kotlin/com/freeletics/flowredux2/extensions/OnEnterLoadSmoothlyLoadingState.kt
@@ -1,0 +1,55 @@
+// Use InlineOnly like the stdlib does to allow having 2 type constraints on SubState
+// where one of the 2 is another type parameter. The compiler usually doesn't allow this
+// and has the BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER check for it but lifts
+// the restriction for methods annotated with @InlineOnly which unfortunately is internal.
+@file:Suppress("INVISIBLE_REFERENCE")
+
+package com.freeletics.flowredux2.extensions
+
+import com.freeletics.flowredux2.BaseBuilder
+import com.freeletics.flowredux2.ChangeableState
+import com.freeletics.flowredux2.ChangedState
+import kotlin.internal.InlineOnly
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * To be used for states that use [onEnterLoadSmoothly] in a state machine.
+ */
+public interface LoadingState<T : LoadingState<T>> {
+    /**
+     * When `true` the UI should show a loading indicator. Otherwise it should just
+     * stay blank.
+     */
+    public val showLoadingIndicator: Boolean
+
+    /**
+     * Returns a new instance of [T] where [showLoadingIndicator] is `true`.
+     */
+    public fun withShowLoadingIndicatorEnabled(): T
+}
+
+/**
+ * A version of [onEnterLoadSmoothly] that simplifies the usage by using the [LoadingState] interface. This way
+ * the state in which [onEnterLoadSmoothly] is used in just needs to implement the interface and the usage of
+ * the DSL method is simplified to only requiring to pass [operation] making it look closer to the regular
+ * `onEnter` and other DSL methods.
+ */
+@InlineOnly
+@ExperimentalCoroutinesApi
+public inline fun <SubState, S : Any> BaseBuilder<SubState, S, *>.onEnterLoadSmoothly(
+    loadingIndicatorDelay: Duration = defaultLoadingIndicatorDelay,
+    minimumLoadingIndicatorDisplayTime: Duration = defaultMinimumLoadingIndicatorDisplayTime,
+    timeSource: TimeSource.WithComparableMarks = TimeSource.Monotonic,
+    noinline operation: suspend ChangeableState<SubState>.() -> ChangedState<S>,
+) where SubState : S, SubState : LoadingState<SubState> {
+    onEnterLoadSmoothly(
+        startShowingLoadingIndicator = { withShowLoadingIndicatorEnabled() },
+        shouldDelayLoadingIndicator = { !showLoadingIndicator },
+        loadingIndicatorDelay = loadingIndicatorDelay,
+        minimumLoadingIndicatorDisplayTime = minimumLoadingIndicatorDisplayTime,
+        timeSource = timeSource,
+        operation = operation,
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,7 @@ android-library = { id = "com.android.library", version.ref = "android-gradle" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+burst = { id = "app.cash.burst", version = "2.10.1" }
 publish = { id = "com.vanniktech.maven.publish", version.ref = "publish" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 binarycompatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binarycompatibility" }


### PR DESCRIPTION
Adds an overload that operates on a `LoadingState` interface. This allows to just implement the interface in the required state subclass and using `onEnterLoadSmoothly` is just like `onEnter` or other DSL methods:
```kotlin
inState<MyLoadingState> { 
    onEnterLoadSmoothly { 
        // load something
        override { /* new state */ }
    }
}
```