### PR TITLE
implement cancelOnState for sub state machines

### DIFF
--- a/flowredux/api/android/flowredux.api
+++ b/flowredux/api/android/flowredux.api
@@ -14,11 +14,14 @@ public abstract class com/freeletics/flowredux2/BaseBuilder {
 	public static synthetic fun collectWhileInStateEffect$default (Lcom/freeletics/flowredux2/BaseBuilder;Lkotlinx/coroutines/flow/Flow;Lcom/freeletics/flowredux2/ExecutionPolicy;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
 	public final fun on (Lkotlin/reflect/KClass;Lcom/freeletics/flowredux2/ExecutionPolicy;Lkotlin/jvm/functions/Function3;)V
 	public final fun onActionEffect (Lkotlin/reflect/KClass;Lcom/freeletics/flowredux2/ExecutionPolicy;Lkotlin/jvm/functions/Function3;)V
-	public final fun onActionStartStateMachine (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
+	public final fun onActionStartStateMachine (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
+	public static synthetic fun onActionStartStateMachine$default (Lcom/freeletics/flowredux2/BaseBuilder;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
 	public final fun onEnter (Lkotlin/jvm/functions/Function2;)V
 	public final fun onEnterEffect (Lkotlin/jvm/functions/Function2;)V
+	public final fun onEnterStartStateMachine (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
 	public final fun onEnterStartStateMachine (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
-	public final fun onEnterStartStateMachine (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
+	public static synthetic fun onEnterStartStateMachine$default (Lcom/freeletics/flowredux2/BaseBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+	public static synthetic fun onEnterStartStateMachine$default (Lcom/freeletics/flowredux2/BaseBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
 }
 
 public final class com/freeletics/flowredux2/ChangeableState : com/freeletics/flowredux2/State {

--- a/flowredux/api/jvm/flowredux.api
+++ b/flowredux/api/jvm/flowredux.api
@@ -10,11 +10,14 @@ public abstract class com/freeletics/flowredux2/BaseBuilder {
 	public static synthetic fun collectWhileInStateEffect$default (Lcom/freeletics/flowredux2/BaseBuilder;Lkotlinx/coroutines/flow/Flow;Lcom/freeletics/flowredux2/ExecutionPolicy;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
 	public final fun on (Lkotlin/reflect/KClass;Lcom/freeletics/flowredux2/ExecutionPolicy;Lkotlin/jvm/functions/Function3;)V
 	public final fun onActionEffect (Lkotlin/reflect/KClass;Lcom/freeletics/flowredux2/ExecutionPolicy;Lkotlin/jvm/functions/Function3;)V
-	public final fun onActionStartStateMachine (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
+	public final fun onActionStartStateMachine (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
+	public static synthetic fun onActionStartStateMachine$default (Lcom/freeletics/flowredux2/BaseBuilder;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
 	public final fun onEnter (Lkotlin/jvm/functions/Function2;)V
 	public final fun onEnterEffect (Lkotlin/jvm/functions/Function2;)V
+	public final fun onEnterStartStateMachine (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
 	public final fun onEnterStartStateMachine (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
-	public final fun onEnterStartStateMachine (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
+	public static synthetic fun onEnterStartStateMachine$default (Lcom/freeletics/flowredux2/BaseBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+	public static synthetic fun onEnterStartStateMachine$default (Lcom/freeletics/flowredux2/BaseBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
 }
 
 public final class com/freeletics/flowredux2/ChangeableState : com/freeletics/flowredux2/State {

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/BaseBuilder.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/BaseBuilder.kt
@@ -223,11 +223,13 @@ public abstract class BaseBuilder<InputState : S, S : Any, A : Any> internal con
 
     public fun <SubStateMachineState : Any> onEnterStartStateMachine(
         stateMachineFactoryBuilder: State<InputState>.() -> FlowReduxStateMachineFactory<SubStateMachineState, A>,
+        cancelOnState: (SubStateMachineState) -> Boolean = { false },
         handler: suspend ChangeableState<InputState>.(SubStateMachineState) -> ChangedState<S>,
     ) {
         onEnterStartStateMachine(
             stateMachineFactoryBuilder = stateMachineFactoryBuilder,
             actionMapper = { it },
+            cancelOnState = cancelOnState,
             handler = handler,
         )
     }
@@ -235,6 +237,7 @@ public abstract class BaseBuilder<InputState : S, S : Any, A : Any> internal con
     public fun <SubStateMachineState : Any, SubStateMachineAction : Any> onEnterStartStateMachine(
         stateMachineFactoryBuilder: State<InputState>.() -> FlowReduxStateMachineFactory<SubStateMachineState, SubStateMachineAction>,
         actionMapper: (A) -> SubStateMachineAction?,
+        cancelOnState: (SubStateMachineState) -> Boolean = { false },
         handler: suspend ChangeableState<InputState>.(SubStateMachineState) -> ChangedState<S>,
     ) {
         sideEffectBuilders += SideEffectBuilder(isInState) { initialState ->
@@ -242,6 +245,7 @@ public abstract class BaseBuilder<InputState : S, S : Any, A : Any> internal con
                 isInState = sideEffectIsInState(initialState),
                 subStateMachineFactory = ChangeableState(initialState).stateMachineFactoryBuilder(),
                 actionMapper = actionMapper,
+                cancelOnState = cancelOnState,
                 handler = handler,
             )
         }
@@ -249,12 +253,14 @@ public abstract class BaseBuilder<InputState : S, S : Any, A : Any> internal con
 
     public inline fun <reified SubAction : A, SubStateMachineState : Any> onActionStartStateMachine(
         noinline stateMachineFactoryBuilder: State<InputState>.(SubAction) -> FlowReduxStateMachineFactory<SubStateMachineState, A>,
+        noinline cancelOnState: (SubStateMachineState) -> Boolean = { false },
         noinline handler: suspend ChangeableState<InputState>.(SubStateMachineState) -> ChangedState<S>,
     ) {
         onActionStartStateMachine(
             actionClass = SubAction::class,
             stateMachineFactoryBuilder = stateMachineFactoryBuilder,
             actionMapper = { it },
+            cancelOnState = cancelOnState,
             handler = handler,
         )
     }
@@ -262,12 +268,14 @@ public abstract class BaseBuilder<InputState : S, S : Any, A : Any> internal con
     public inline fun <reified SubAction : A, SubStateMachineState : Any, SubStateMachineAction : Any> onActionStartStateMachine(
         noinline stateMachineFactoryBuilder: State<InputState>.(SubAction) -> FlowReduxStateMachineFactory<SubStateMachineState, SubStateMachineAction>,
         noinline actionMapper: (A) -> SubStateMachineAction?,
+        noinline cancelOnState: (SubStateMachineState) -> Boolean = { false },
         noinline handler: suspend ChangeableState<InputState>.(SubStateMachineState) -> ChangedState<S>,
     ) {
         onActionStartStateMachine(
             actionClass = SubAction::class,
             stateMachineFactoryBuilder = stateMachineFactoryBuilder,
             actionMapper = actionMapper,
+            cancelOnState = cancelOnState,
             handler = handler,
         )
     }
@@ -277,6 +285,7 @@ public abstract class BaseBuilder<InputState : S, S : Any, A : Any> internal con
         actionClass: KClass<out SubAction>,
         stateMachineFactoryBuilder: State<InputState>.(SubAction) -> FlowReduxStateMachineFactory<SubStateMachineState, SubStateMachineAction>,
         actionMapper: (A) -> SubStateMachineAction?,
+        cancelOnState: (SubStateMachineState) -> Boolean = { false },
         handler: suspend ChangeableState<InputState>.(SubStateMachineState) -> ChangedState<S>,
     ) {
         sideEffectBuilders += SideEffectBuilder(isInState) {
@@ -285,6 +294,7 @@ public abstract class BaseBuilder<InputState : S, S : Any, A : Any> internal con
                 stateMachineFactoryBuilder = stateMachineFactoryBuilder,
                 subActionClass = actionClass,
                 actionMapper = actionMapper,
+                cancelOnState = cancelOnState,
                 handler = handler,
             )
         }

--- a/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterStartStateMachine.kt
+++ b/flowredux/src/commonMain/kotlin/com/freeletics/flowredux2/sideeffects/OnEnterStartStateMachine.kt
@@ -3,11 +3,14 @@ package com.freeletics.flowredux2.sideeffects
 import com.freeletics.flowredux2.ChangeableState
 import com.freeletics.flowredux2.ChangedState
 import com.freeletics.flowredux2.FlowReduxStateMachineFactory
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 
 @ExperimentalCoroutinesApi
@@ -15,30 +18,30 @@ internal class OnEnterStartStateMachine<SubStateMachineState : Any, SubStateMach
     override val isInState: IsInState<S>,
     private val subStateMachineFactory: FlowReduxStateMachineFactory<SubStateMachineState, SubStateMachineAction>,
     private val actionMapper: (A) -> SubStateMachineAction?,
+    private val cancelOnState: (SubStateMachineState) -> Boolean,
     private val handler: suspend ChangeableState<InputState>.(SubStateMachineState) -> ChangedState<S>,
 ) : ActionBasedSideEffect<InputState, S, A>() {
     override fun produceState(getState: GetState<S>): Flow<ChangedState<S>> {
         return channelFlow {
-            val subStateMachine = subStateMachineFactory.launchIn(this)
-            launch {
-                subStateMachine.state
-                    .flatMapConcat { subStateMachineState ->
-                        changeState(getState) { inputState ->
-                            ChangeableState(inputState).handler(subStateMachineState)
+            val scope = CoroutineScope(coroutineContext + SupervisorJob(coroutineContext.job))
+
+            val stateMachine = subStateMachineFactory.launchIn(scope)
+
+            scope.launch {
+                stateMachine.state.collect {
+                    runOnlyIfInInputState(getState) { parentState ->
+                        val changedState = ChangeableState(parentState).handler(it)
+                        send(changedState)
+                        if (cancelOnState(it)) {
+                            scope.cancel()
                         }
                     }
-                    .collect {
-                        send(it)
-                    }
+                }
             }
 
             actions
-                .mapNotNull { actionMapper(it) }
-                .collect { action ->
-                    runOnlyIfInInputState(getState) {
-                        subStateMachine.dispatch(action)
-                    }
-                }
+                .mapNotNull(actionMapper)
+                .collect { stateMachine.dispatch(it) }
         }
     }
 }


### PR DESCRIPTION
Currently a sub state machine will mostly run endlessly. The only 2 cancel mechanisms are:
- the state machine leaving the containing block (`inState`, `condition` etc)
- for `onActionStart...`: the same action being received another time which will cancel the existing state machine and start a new one

This adds an optional `cancelOnState` lambdam which allows cancelling based on the state emitted by the sub state machine, allowing to write small focused state machines with a terminal state (for example performing some network request and then going to success/failed). 

Addresses #880 